### PR TITLE
add ipfs parsing

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -51,7 +51,8 @@ func main() {
 	// TODO: what happens when operator id changes
 	// TODO: what happens if new validators -> new validatorIndexes. Affects vebo adapter. We should
 	// TODO: where to get validatorIndexes and refSlot from
-	veboAdapter, err := vebo.NewVeboAdapter(networkConfig.WsURL, networkConfig.VEBOAddress, []*big.Int{networkConfig.CSMStakingModuleID}, []*big.Int{appConfig.OperatorID}, []*big.Int{}, []*big.Int{})
+	// TODO: where to get ipfsEndpoint from? Dappmanager or given remote
+	veboAdapter, err := vebo.NewVeboAdapter(networkConfig.WsURL, networkConfig.VEBOAddress, []*big.Int{networkConfig.CSMStakingModuleID}, []*big.Int{appConfig.OperatorID}, []*big.Int{}, []*big.Int{}, "")
 	if err != nil {
 		log.Fatalf("Failed to initialize Vebo adapter: %v", err)
 	}

--- a/internal/adapters/storage/lido_report_adapter.go
+++ b/internal/adapters/storage/lido_report_adapter.go
@@ -13,21 +13,24 @@ func (fs *Storage) GetLidoReport(start, end string) (domain.Reports, error) {
 	if err != nil {
 		return nil, err
 	}
-	reportData := make(map[string]domain.Report)
+	reportData := make(map[uint32]domain.Report)
 	for epoch, report := range performanceData {
-		epochInt, err := strconv.Atoi(epoch)
-		if err != nil {
-			continue
-		}
-		startInt, err := strconv.Atoi(start)
+		
+		// convert start and end to uint32
+		startInt, err := strconv.ParseUint(start, 10, 32)
 		if err != nil {
 			return nil, err
 		}
-		endInt, err := strconv.Atoi(end)
+		endInt, err := strconv.ParseUint(end, 10, 32)
 		if err != nil {
 			return nil, err
 		}
-		if epochInt >= startInt && epochInt <= endInt {
+
+		// Explicitly convert to uint32 since ParseUint returns uint64
+		startUint32 := uint32(startInt)
+		endUint32 := uint32(endInt)
+
+		if epoch >= startUint32 && epoch <= endUint32 {
 			reportData[epoch] = report
 		}
 	}
@@ -50,18 +53,18 @@ func (fs *Storage) SaveLidoReport(reports domain.Reports) error {
 }
 
 // loadPerformance loads the validator performance data from the JSON file
-func loadPerformance(fs *Storage) (map[string]domain.Report, error) {
+func loadPerformance(fs *Storage) (map[uint32]domain.Report, error) {
 	file, err := os.ReadFile(fs.PerformanceFile)
 	if err != nil {
 		return nil, err
 	}
-	var data map[string]domain.Report
+	var data map[uint32]domain.Report
 	err = json.Unmarshal(file, &data)
 	return data, err
 }
 
 // savePerformance saves the validator performance data to the JSON file
-func savePerformance(fs *Storage, data map[string]domain.Report) error {
+func savePerformance(fs *Storage, data map[uint32]domain.Report) error {
 	file, err := json.MarshalIndent(data, "", "  ")
 	if err != nil {
 		return err

--- a/internal/adapters/vebo/vebo_adapter.go
+++ b/internal/adapters/vebo/vebo_adapter.go
@@ -2,11 +2,14 @@ package vebo
 
 import (
 	"context"
+	"encoding/json"
+	"io"
 	"lido-events/internal/adapters/vebo/bindings"
 	"lido-events/internal/application/domain"
 	"lido-events/internal/application/ports"
 	"log"
 	"math/big"
+	"net/http"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -20,7 +23,35 @@ type VeboAdapter struct {
 	NodeOperatorId  []*big.Int
 	ValidatorIndex  []*big.Int // TODO: where to get it?
 	RefSlot         []*big.Int // TODO: where to get it?
+	ipfsEndpoint    string // Add IPFS endpoint URL field
 }
+
+type IPFSData struct {
+    Blockstamp struct {
+        BlockHash      string `json:"block_hash"`
+        BlockNumber    int    `json:"block_number"`
+        BlockTimestamp int    `json:"block_timestamp"`
+        RefEpoch       int    `json:"ref_epoch"`
+        RefSlot        int    `json:"ref_slot"`
+        SlotNumber     int    `json:"slot_number"`
+        StateRoot      string `json:"state_root"`
+    } `json:"blockstamp"`
+    Distributable int64 `json:"distributable"`
+    Frame         []int `json:"frame"`
+    Operators     map[string]struct {
+        Distributed int64 `json:"distributed"`
+        Stuck       bool  `json:"stuck"`
+        Validators  map[string]struct {
+            Perf struct {
+                Assigned int `json:"assigned"`
+                Included int `json:"included"`
+            } `json:"perf"`
+            Slashed bool `json:"slashed"`
+        } `json:"validators"`
+    } `json:"operators"`
+    Threshold float64 `json:"threshold"`
+}
+
 
 func NewVeboAdapter(
 	wsURL string,
@@ -29,6 +60,7 @@ func NewVeboAdapter(
 	nodeOperatorId []*big.Int,
 	validatorIndex []*big.Int,
 	refSlot []*big.Int,
+	ipfsEndpoint string, 
 ) (*VeboAdapter, error) {
 	client, err := ethclient.Dial(wsURL)
 	if err != nil {
@@ -42,6 +74,7 @@ func NewVeboAdapter(
 		NodeOperatorId:  nodeOperatorId,
 		ValidatorIndex:  validatorIndex,
 		RefSlot:         refSlot,
+		ipfsEndpoint:    ipfsEndpoint, // Set the IPFS endpoint
 	}, nil
 }
 
@@ -92,3 +125,43 @@ func (va *VeboAdapter) WatchVeboEvents(ctx context.Context, handlers ports.VeboH
 
 	return nil
 }
+
+// FetchAndParseIPFSContent fetches the IPFS content and parses it into a domain.Report struct.
+func (va *VeboAdapter) FetchAndParseIPFSContent(ctx context.Context, ipfsHash string, operatorId domain.OperatorId) (*domain.Report, error) {
+    url := va.ipfsEndpoint + "/api/v0/cat?arg=" + ipfsHash
+    response, err := http.Get(url)
+    if err != nil {
+        return nil, err
+    }
+    defer response.Body.Close()
+
+    data, err := io.ReadAll(response.Body)
+    if err != nil {
+        return nil, err
+    }
+
+    var ipfsData IPFSData
+    err = json.Unmarshal(data, &ipfsData)
+    if err != nil {
+        return nil, err
+    }
+
+    report := &domain.Report{
+        Threshold: ipfsData.Threshold,
+        Validators: make(domain.Validators),
+		RefSlot: uint32(ipfsData.Blockstamp.RefSlot),
+    }
+
+	operatorKey := operatorId.String()
+    if operator, ok := ipfsData.Operators[operatorKey]; ok {
+        for pubKey, validator := range operator.Validators {
+            report.Validators[pubKey] = domain.ValidatorPerformance{
+                Included: uint(validator.Perf.Included),
+                Assigned: uint(validator.Perf.Assigned),
+            }
+        }
+    }
+
+    return report, nil
+}
+

--- a/internal/application/domain/config.go
+++ b/internal/application/domain/config.go
@@ -7,7 +7,7 @@ type TelegramConfig struct {
 	ChatID int64  `json:"chatId"`
 }
 
-type OperatorId *big.Int
+type OperatorId = *big.Int
 
 type Config struct {
 	OperatorID OperatorId     `json:"operatorId"`

--- a/internal/application/domain/lido_report.go
+++ b/internal/application/domain/lido_report.go
@@ -1,15 +1,16 @@
 package domain
 
-type Reports map[string]Report // indexed by epoch
+type Reports map[uint32]Report // indexed by epoch
 
 type Report struct {
-	Threshold  string
+	Threshold float64
 	Validators Validators
+	RefSlot uint32 // lido report returns `ref_slot`, which can be converted to epoch
 }
 
 type Validators map[string]ValidatorPerformance // indexed by validator pubkey
 
 type ValidatorPerformance struct {
-	Included string
-	Assigned string
+	Included uint
+	Assigned uint
 }

--- a/internal/application/ports/vebo_port.go
+++ b/internal/application/ports/vebo_port.go
@@ -8,6 +8,7 @@ import (
 
 type VeboPort interface {
 	WatchVeboEvents(ctx context.Context, handlers VeboHandlers) error
+	FetchAndParseIPFSContent(ctx context.Context, hash string, operatorId domain.OperatorId) (*domain.Report, error)
 }
 
 type VeboHandlers interface {

--- a/internal/application/services/storage_service.go
+++ b/internal/application/services/storage_service.go
@@ -21,12 +21,12 @@ func NewStorageService(storage ports.StoragePort) *StorageService {
 }
 
 // GetLidoReport retrieves the Lido report for the given range of epochs
-func (os *StorageService) GetLidoReport(start, end string) (map[string]domain.Report, error) {
+func (os *StorageService) GetLidoReport(start, end string) (map[uint32]domain.Report, error) {
 	return os.storagePort.GetLidoReport(start, end)
 }
 
 // SaveLidoReport saves the Lido report to the repository
-func (os *StorageService) SaveLidoReport(report map[string]domain.Report) error {
+func (os *StorageService) SaveLidoReport(report map[uint32]domain.Report) error {
 	err := os.storagePort.SaveLidoReport(report)
 	if err != nil {
 		return err


### PR DESCRIPTION
IPFS parsing is the responsibility of whoever is in charge of parsing the VEBO smart contract (defined in vebo port).

- Given an IPFS hash, vebo_adapter is now able to parse it with `FetchAndParseIPFSContent()`, which returns a the report in a way that our domain can read (domain.report)
- changed reports map:
  - from: `type Reports map[string]Report`
  - to: `type Reports map[uint32]Report`