### PR TITLE
Set last fetched block to 0 when adding operator

### DIFF
--- a/internal/adapters/api/api_adapter.go
+++ b/internal/adapters/api/api_adapter.go
@@ -192,12 +192,12 @@ func (h *APIHandler) AddOperator(w http.ResponseWriter, r *http.Request) {
 	// TODO: this logic should be in the services layer
 	if err := h.StoragePort.SaveDistributionLogLastProcessedBlock(0); err != nil {
 		logger.ErrorWithPrefix("API", "Failed to update DistributionLogLastProcessedBlock: %v", err)
-		writeErrorResponse(w, "Failed to update DistributionLogLastProcessedBlock", http.StatusInternalServerError)
+		writeErrorResponse(w, "Failed to reset DistributionLogLastProcessedBlock", http.StatusInternalServerError)
 		return
 	}
 	if err := h.StoragePort.SaveValidatorExitRequestLastProcessedBlock(0); err != nil {
 		logger.ErrorWithPrefix("API", "Failed to update ValidatorExitRequestLastProcessedBlock: %v", err)
-		writeErrorResponse(w, "Failed to update ValidatorExitRequestLastProcessedBlock", http.StatusInternalServerError)
+		writeErrorResponse(w, "Failed to reset ValidatorExitRequestLastProcessedBlock", http.StatusInternalServerError)
 		return
 	}
 


### PR DESCRIPTION
Set last fetched block to 0 when adding operator in both events scanner: distributionLogUpdated and exitRequest

This will trigger the scanners to search for events for the added operator id from the beggining