### PR TITLE
Simplify main logic

### DIFF
--- a/internal/adapters/api/api_adapter.go
+++ b/internal/adapters/api/api_adapter.go
@@ -20,6 +20,14 @@ type APIHandler struct {
 	adapterPrefix string
 }
 
+// Ensure APIHandler implements the ports.API interface
+var _ ports.API = (*APIHandler)(nil)
+
+// GetRouter implements the ports.API interface
+func (h *APIHandler) GetRouter() http.Handler {
+	return h.Router
+}
+
 // NewAPIAdapter initializes the APIHandler and sets up routes with CORS enabled
 func NewAPIAdapter(storagePort ports.StoragePort, allowedOrigins []string) *APIHandler {
 	h := &APIHandler{
@@ -135,7 +143,7 @@ func (h *APIHandler) DeleteOperator(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// check it exists calling GetOperatorIds
+	// Check if operator ID exists
 	operatorIds, err := h.StoragePort.GetOperatorIds()
 	if err != nil {
 		logger.ErrorWithPrefix("API", "Failed to fetch operator IDs: %v", err)
@@ -191,7 +199,7 @@ func (h *APIHandler) AddOperator(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// check if operator id already exists and if so return ok
+	// Check if operator ID already exists
 	operatorIds, err := h.StoragePort.GetOperatorIds()
 	if err != nil {
 		logger.ErrorWithPrefix("API", "Failed to fetch operator IDs: %v", err)
@@ -215,7 +223,7 @@ func (h *APIHandler) AddOperator(w http.ResponseWriter, r *http.Request) {
 
 	// Set last block processed to 0, this will trigger the events scanner to start from the beginning
 	// and look for events for the new operator ID
-	// TODO: this logic should be in the services layer
+	// TODO: Consider moving this logic to the services layer
 	if err := h.StoragePort.SaveDistributionLogLastProcessedBlock(0); err != nil {
 		logger.ErrorWithPrefix("API", "Failed to update DistributionLogLastProcessedBlock: %v", err)
 		writeErrorResponse(w, "Failed to reset DistributionLogLastProcessedBlock", http.StatusInternalServerError)

--- a/internal/adapters/csFeeDistributor/csfeedistributor_adapter.go
+++ b/internal/adapters/csFeeDistributor/csfeedistributor_adapter.go
@@ -50,10 +50,6 @@ func (csfa *CsFeeDistributorAdapter) WatchCsFeeDistributorEvents(ctx context.Con
 			select {
 			case event := <-distributionDataUpdatedChan:
 				handleDistributionDataUpdated(event)
-				return
-			// case err := <-sub.Err():
-			// 	// Subscription error should be handled by returning it to the service layer.
-			// 	return
 			case <-ctx.Done():
 				return
 			}

--- a/internal/adapters/csModule/csmodule_adapter.go
+++ b/internal/adapters/csModule/csmodule_adapter.go
@@ -203,49 +203,34 @@ func (csma *CsModuleAdapter) WatchCsModuleEvents(ctx context.Context, handlers p
 			select {
 			case event := <-depositedSigningKeysChangedChan:
 				handlers.HandleDepositedSigningKeysCountChanged(event)
-				return
 			case event := <-elRewardsStealingPenaltyReportedChan:
 				handlers.HandleElRewardsStealingPenaltyReported(event)
-				return
 			case event := <-elRewardsStealingPenaltySettledChan:
 				handlers.HandleElRewardsStealingPenaltySettled(event)
-				return
 			case event := <-elRewardsStealingPenaltyCancelledChan:
 				handlers.HandleElRewardsStealingPenaltyCancelled(event)
-				return
 			case event := <-initialSlashingSubmittedChan:
 				handlers.HandleInitialSlashingSubmitted(event)
-				return
 			case event := <-keyRemovalChargeAppliedChan:
 				handlers.HandleKeyRemovalChargeApplied(event)
-				return
 			case event := <-nodeOperatorManagerAddressChangeProposedChan:
 				handlers.HandleNodeOperatorManagerAddressChangeProposed(event)
-				return
 			case event := <-nodeOperatorManagerAddressChangedChan:
 				handlers.HandleNodeOperatorManagerAddressChanged(event)
-				return
 			case event := <-nodeOperatorRewardAddressChangeProposedChan:
 				handlers.HandleNodeOperatorRewardAddressChangeProposed(event)
-				return
 			case event := <-nodeOperatorRewardAddressChangedChan:
 				handlers.HandleNodeOperatorRewardAddressChanged(event)
-				return
 			case event := <-stuckSigningKeysCountChangedChan:
 				handlers.HandleStuckSigningKeysCountChanged(event)
-				return
 			case event := <-vettedSigningKeysCountDecreasedChan:
 				handlers.HandleVettedSigningKeysCountDecreased(event)
-				return
 			case event := <-withdrawalSubmittedChan:
 				handlers.HandleWithdrawalSubmitted(event)
-				return
 			case event := <-totalSigningKeysCountChangedChan:
 				handlers.HandleTotalSigningKeysCountChanged(event)
-				return
 			case event := <-publicReleaseChan:
 				handlers.HandlePublicRelease(event)
-				return
 
 			case <-ctx.Done():
 				return

--- a/internal/adapters/proxyApi/proxy_api_adapter.go
+++ b/internal/adapters/proxyApi/proxy_api_adapter.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"net/url"
 
+	"lido-events/internal/application/ports"
+
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 )
@@ -15,6 +17,14 @@ type APIHandler struct {
 	Router        *mux.Router
 	proxyApiURL   string
 	adapterPrefix string
+}
+
+// Ensure APIHandler implements the ports.ProxyAPI interface
+var _ ports.ProxyAPI = (*APIHandler)(nil)
+
+// GetRouter implements the ports.ProxyAPI interface
+func (h *APIHandler) GetRouter() http.Handler {
+	return h.Router
 }
 
 // NewProxyAPIAdapter initializes the APIHandler and sets up routes

--- a/internal/adapters/vebo/vebo_adapter.go
+++ b/internal/adapters/vebo/vebo_adapter.go
@@ -88,10 +88,6 @@ func (va *VeboAdapter) WatchReportSubmittedEvents(ctx context.Context, handleRep
 			select {
 			case event := <-reportSubmittedChan:
 				handleReportSubmittedEvent(event)
-				return
-			// case err := <-subReport.Err():
-			// 	// Exit on subscription error
-			// 	return
 			case <-ctx.Done():
 				return
 			}

--- a/internal/application/ports/api_port.go
+++ b/internal/application/ports/api_port.go
@@ -1,0 +1,8 @@
+package ports
+
+import "net/http"
+
+// API is the interface for the API adapter.
+type API interface {
+	GetRouter() http.Handler
+}

--- a/internal/application/ports/proxy_api_port.go
+++ b/internal/application/ports/proxy_api_port.go
@@ -1,0 +1,8 @@
+package ports
+
+import "net/http"
+
+// ProxyAPI is the interface for the Proxy API adapter.
+type ProxyAPI interface {
+	GetRouter() http.Handler
+}

--- a/internal/application/services/api_server.go
+++ b/internal/application/services/api_server.go
@@ -1,0 +1,43 @@
+// internal/application/services/api_server_service.go
+package services
+
+import (
+	"context"
+	"lido-events/internal/application/ports"
+	"lido-events/internal/logger"
+	"net/http"
+	"strconv"
+	"sync"
+)
+
+type APIServerService struct {
+	server        *http.Server
+	servicePrefix string
+}
+
+func NewAPIServerService(apiAdapter ports.API, port uint64) *APIServerService {
+	return &APIServerService{
+		server: &http.Server{
+			Addr:    ":" + strconv.FormatUint(port, 10),
+			Handler: apiAdapter.GetRouter(),
+		},
+		servicePrefix: "API",
+	}
+}
+
+func (s *APIServerService) Start(wg *sync.WaitGroup) {
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		logger.InfoWithPrefix(s.servicePrefix, "server started on %s", s.server.Addr)
+		if err := s.server.ListenAndServe(); err != http.ErrServerClosed {
+			logger.FatalWithPrefix(s.servicePrefix, "server ListenAndServe: %v", err)
+		}
+	}()
+}
+
+func (s *APIServerService) Shutdown(ctx context.Context) {
+	if err := s.server.Shutdown(ctx); err != nil {
+		logger.WarnWithPrefix(s.servicePrefix, "server Shutdown: %v", err)
+	}
+}

--- a/internal/application/services/proxy_api_server.go
+++ b/internal/application/services/proxy_api_server.go
@@ -1,0 +1,43 @@
+// internal/application/services/proxy_api_server_service.go
+package services
+
+import (
+	"context"
+	"lido-events/internal/application/ports"
+	"lido-events/internal/logger"
+	"net/http"
+	"strconv"
+	"sync"
+)
+
+type ProxyAPIServerService struct {
+	server        *http.Server
+	servicePrefix string
+}
+
+func NewProxyAPIServerService(proxyApiAdapter ports.ProxyAPI, port uint64) *ProxyAPIServerService {
+	return &ProxyAPIServerService{
+		server: &http.Server{
+			Addr:    ":" + strconv.FormatUint(port, 10),
+			Handler: proxyApiAdapter.GetRouter(),
+		},
+		servicePrefix: "Proxy API",
+	}
+}
+
+func (s *ProxyAPIServerService) Start(wg *sync.WaitGroup) {
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		logger.InfoWithPrefix(s.servicePrefix, "server started on %s", s.server.Addr)
+		if err := s.server.ListenAndServe(); err != http.ErrServerClosed {
+			logger.FatalWithPrefix(s.servicePrefix, "server ListenAndServe: %v", err)
+		}
+	}()
+}
+
+func (s *ProxyAPIServerService) Shutdown(ctx context.Context) {
+	if err := s.server.Shutdown(ctx); err != nil {
+		logger.WarnWithPrefix(s.servicePrefix, "server Shutdown: %v", err)
+	}
+}


### PR DESCRIPTION
Simplify main logic:
- create api services 
- Move signalling of api servers to services
- Simplify code of wait for initial config
- Remove exits if etherum client subscription fails