### PR TITLE
Add concurrency to Exit Req

### DIFF
--- a/internal/adapters/storage/exit_requests.go
+++ b/internal/adapters/storage/exit_requests.go
@@ -38,6 +38,9 @@ func (fs *Storage) SaveExitRequests(operatorID *big.Int, requests domain.ExitReq
 
 // SaveExitRequest saves an individual exit request for a specific operator ID and validator index.
 func (fs *Storage) SaveExitRequest(operatorID *big.Int, validatorIndex string, exitRequest domain.ExitRequest) error {
+	fs.mu.Lock()         // Lock before modifying
+	defer fs.mu.Unlock() // Unlock when done
+
 	db, err := fs.LoadDatabase()
 	if err != nil {
 		return err
@@ -80,6 +83,9 @@ func (fs *Storage) GetExitRequests(operatorID string) (domain.ExitRequests, erro
 
 // UpdateExitRequestStatus updates the status of a specific exit request for a validator index.
 func (fs *Storage) UpdateExitRequestStatus(operatorID string, validatorIndex string, status domain.ValidatorStatus) error {
+	fs.mu.Lock()         // Lock before modifying
+	defer fs.mu.Unlock() // Unlock when done
+
 	db, err := fs.LoadDatabase()
 	if err != nil {
 		return err
@@ -106,6 +112,9 @@ func (fs *Storage) UpdateExitRequestStatus(operatorID string, validatorIndex str
 
 // DeleteExitRequest removes an exit request for a specific operator ID and validator index.
 func (fs *Storage) DeleteExitRequest(operatorID string, validatorIndex string) error {
+	fs.mu.Lock()         // Lock before modifying
+	defer fs.mu.Unlock() // Unlock when done
+
 	db, err := fs.LoadDatabase()
 	if err != nil {
 		return err


### PR DESCRIPTION
- exit request spawns a goroutine to add concurrency. Limited to 10 concurrent goroutines executing thanks to a semaphore, a channel with capacity 10
- added mutex locking in writing operations in db