### PR TITLE
Do not send performance notification if report is older than 24h

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -97,7 +97,7 @@ func main() {
 	distributionLogUpdatedScannerService := services.NewDistributionLogUpdatedEventScanner(storageAdapter, notifierAdapter, executionAdapter, csFeeDistributorImplAdapter, networkConfig.CsFeeDistributorBlockDeployment)
 	validatorExitRequestScannerService := services.NewValidatorExitRequestEventScanner(storageAdapter, notifierAdapter, veboAdapter, executionAdapter, beaconchainAdapter, networkConfig.VeboBlockDeployment)
 	validatorEjectorService := services.NewValidatorEjectorService(storageAdapter, notifierAdapter, exitValidatorAdapter, beaconchainAdapter)
-	pendingHashesLoaderService := services.NewPendingHashesLoader(storageAdapter, notifierAdapter, ipfsAdapter)
+	pendingHashesLoaderService := services.NewPendingHashesLoader(storageAdapter, notifierAdapter, ipfsAdapter, networkConfig.MinGenesisTime)
 	// relaysCheckerService := services.NewRelayCronService(relaysAllowedAdapter, relaysUsedAdapter, notifierAdapter)
 
 	// Start domain services

--- a/internal/application/services/loadPendingHashes.go
+++ b/internal/application/services/loadPendingHashes.go
@@ -175,7 +175,7 @@ func (phl *PendingHashesLoader) CheckAndNotifyPerformance(operatorID *big.Int, v
 	// Check if the report is older than 24h (86400 seconds)
 	// Only skip if it's older than 24h
 	if timeDiff > 86400 {
-		logger.DebugWithPrefix(phl.servicePrefix, "Skipping notification for operator ID %s, report (epoch %d) is older than 6 days", operatorID.String(), originalReport.Frame[1])
+		logger.DebugWithPrefix(phl.servicePrefix, "Skipping notification for operator ID %s, report (epoch %d) is older than 24h", operatorID.String(), originalReport.Frame[1])
 		return
 	}
 
@@ -192,8 +192,8 @@ func (phl *PendingHashesLoader) CheckAndNotifyPerformance(operatorID *big.Int, v
 		// Add bad validators' performance
 		message += strings.Join(badValidators, "\n") + "\n"
 
-		// Log the warning message
-		logger.WarnWithPrefix(phl.servicePrefix, message)
+		// Log the notification message
+		logger.InfoWithPrefix(phl.servicePrefix, "Sending bad performance notification for report epoch %d", originalReport.Frame[1])
 
 		// Send the notification
 		if err := phl.notifierPort.SendNotification(message); err != nil {
@@ -214,8 +214,8 @@ func (phl *PendingHashesLoader) CheckAndNotifyPerformance(operatorID *big.Int, v
 		// Add good validators' performance
 		message += strings.Join(goodValidators, "\n") + "\n"
 
-		// Log the success message
-		logger.InfoWithPrefix(phl.servicePrefix, message)
+		// Log the notification message
+		logger.InfoWithPrefix(phl.servicePrefix, "Sending good performance notification for report epoch %d", originalReport.Frame[1])
 
 		// Send the notification
 		if err := phl.notifierPort.SendNotification(message); err != nil {

--- a/internal/application/services/loadPendingHashes.go
+++ b/internal/application/services/loadPendingHashes.go
@@ -172,10 +172,9 @@ func (phl *PendingHashesLoader) CheckAndNotifyPerformance(operatorID *big.Int, v
 	// Format the time ago string
 	timeAgo := fmt.Sprintf("%d days and %d hours ago", days, hours)
 
-	// Check if the report is older than 6 days (604800 seconds)
-	// Only skip if it's older than 6 days
-	if timeDiff > 604800 { // If the report is older than 6 days (604800 seconds)
-		// Log and skip sending notifications if the report is older than 6 days
+	// Check if the report is older than 24h (86400 seconds)
+	// Only skip if it's older than 24h
+	if timeDiff > 86400 {
 		logger.DebugWithPrefix(phl.servicePrefix, "Skipping notification for operator ID %s, report (epoch %d) is older than 6 days", operatorID.String(), originalReport.Frame[1])
 		return
 	}

--- a/internal/config/config_loader.go
+++ b/internal/config/config_loader.go
@@ -163,7 +163,7 @@ func LoadNetworkConfig() (Config, error) {
 			CSModuleAddress:                 common.HexToAddress("0x4562c3e63c2e586cD1651B958C22F88135aCAd4f"),
 			LidoKeysApiUrl:                  "https://keys-api-holesky.testnet.fi",
 			ProxyApiPort:                    proxyApiPort,
-			MinGenesisTime:                  uint64(1695902100),
+			MinGenesisTime:                  uint64(1695902400),
 		}
 	case "mainnet":
 		// Configure default values for the mainnet
@@ -200,7 +200,7 @@ func LoadNetworkConfig() (Config, error) {
 			CSModuleAddress:                 common.HexToAddress("0xdA7dE2ECdDfccC6c3AF10108Db212ACBBf9EA83F"),
 			LidoKeysApiUrl:                  "https://keys-api.lido.fi",
 			ProxyApiPort:                    proxyApiPort,
-			MinGenesisTime:                  uint64(1606824000),
+			MinGenesisTime:                  uint64(1606824023),
 		}
 	default:
 		logger.Fatal("Unknown network: %s", network)


### PR DESCRIPTION
- performance calcualtion only done if the validator had attestation duties in 60 or more epochs (6,4hours)
- performance notification only sent if end epoch of the lido report is not older than 24h.
- fixed genesis time for both holesky & mainnet
- added genesis time to PendingHashesLoader service