### PR TITLE
Allow to scan by pre-defined block ranges in events scanners

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -57,15 +57,15 @@ func main() {
 	beaconchainAdapter := beaconchain.NewBeaconchainAdapter(networkConfig.BeaconchainURL)
 	executionAdapter := execution.NewExecutionAdapter(networkConfig.RpcUrl)
 	exitValidatorAdapter := exitvalidator.NewExitValidatorAdapter(beaconchainAdapter, networkConfig.SignerUrl)
-	csFeeDistributorImplAdapter, err := csfeedistributorimpl.NewCsFeeDistributorImplAdapter(networkConfig.WsURL, networkConfig.CSFeeDistributorAddress)
+	csFeeDistributorImplAdapter, err := csfeedistributorimpl.NewCsFeeDistributorImplAdapter(networkConfig.WsURL, networkConfig.CSFeeDistributorAddress, networkConfig.BlockChunkSize)
 	if err != nil {
 		logger.FatalWithPrefix(logPrefix, "Failed to initialize CsFeeDistributorImplAdapter: %v", err)
 	}
-	veboAdapter, err := vebo.NewVeboAdapter(networkConfig.WsURL, networkConfig.VEBOAddress, storageAdapter)
+	veboAdapter, err := vebo.NewVeboAdapter(networkConfig.WsURL, networkConfig.VEBOAddress, storageAdapter, networkConfig.BlockChunkSize)
 	if err != nil {
 		logger.FatalWithPrefix(logPrefix, "Failed to initialize VeboAdapter: %v", err)
 	}
-	csModuleAdapter, err := csmodule.NewCsModuleAdapter(networkConfig.WsURL, networkConfig.CSModuleAddress, storageAdapter)
+	csModuleAdapter, err := csmodule.NewCsModuleAdapter(networkConfig.WsURL, networkConfig.CSModuleAddress, storageAdapter, networkConfig.BlockChunkSize)
 	if err != nil {
 		logger.FatalWithPrefix(logPrefix, "Failed to initialize CsModuleAdapter: %v", err)
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -57,11 +57,11 @@ func main() {
 	beaconchainAdapter := beaconchain.NewBeaconchainAdapter(networkConfig.BeaconchainURL)
 	executionAdapter := execution.NewExecutionAdapter(networkConfig.RpcUrl)
 	exitValidatorAdapter := exitvalidator.NewExitValidatorAdapter(beaconchainAdapter, networkConfig.SignerUrl)
-	csFeeDistributorImplAdapter, err := csfeedistributorimpl.NewCsFeeDistributorImplAdapter(networkConfig.WsURL, networkConfig.CSFeeDistributorAddress, networkConfig.BlockChunkSize)
+	csFeeDistributorImplAdapter, err := csfeedistributorimpl.NewCsFeeDistributorImplAdapter(networkConfig.RpcUrl, networkConfig.CSFeeDistributorAddress, networkConfig.BlockChunkSize)
 	if err != nil {
 		logger.FatalWithPrefix(logPrefix, "Failed to initialize CsFeeDistributorImplAdapter: %v", err)
 	}
-	veboAdapter, err := vebo.NewVeboAdapter(networkConfig.WsURL, networkConfig.VEBOAddress, storageAdapter, networkConfig.BlockChunkSize)
+	veboAdapter, err := vebo.NewVeboAdapter(networkConfig.WsURL, networkConfig.RpcUrl, networkConfig.VEBOAddress, storageAdapter, networkConfig.BlockChunkSize)
 	if err != nil {
 		logger.FatalWithPrefix(logPrefix, "Failed to initialize VeboAdapter: %v", err)
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -65,7 +65,7 @@ func main() {
 	if err != nil {
 		logger.FatalWithPrefix(logPrefix, "Failed to initialize VeboAdapter: %v", err)
 	}
-	csModuleAdapter, err := csmodule.NewCsModuleAdapter(networkConfig.WsURL, networkConfig.CSModuleAddress, storageAdapter, networkConfig.BlockChunkSize)
+	csModuleAdapter, err := csmodule.NewCsModuleAdapter(networkConfig.WsURL, networkConfig.RpcUrl, networkConfig.CSModuleAddress, storageAdapter, networkConfig.BlockChunkSize)
 	if err != nil {
 		logger.FatalWithPrefix(logPrefix, "Failed to initialize CsModuleAdapter: %v", err)
 	}

--- a/internal/adapters/csFeeDistributorImpl/csFeeDistributorImpl_adapter.go
+++ b/internal/adapters/csFeeDistributorImpl/csFeeDistributorImpl_adapter.go
@@ -14,7 +14,7 @@ import (
 type CsFeeDistributorImplAdapter struct {
 	rpcClient               *ethclient.Client
 	CsFeeDistributorAddress common.Address
-	BlockChunkSize          uint64 // Configurable block chunk size
+	blockChunkSize          uint64 // Configurable block chunk size
 }
 
 func NewCsFeeDistributorImplAdapter(
@@ -26,7 +26,7 @@ func NewCsFeeDistributorImplAdapter(
 	return &CsFeeDistributorImplAdapter{
 		rpcClient:               rpcClient,
 		CsFeeDistributorAddress: csFeeDistributorAddress,
-		BlockChunkSize:          blockChunkSize,
+		blockChunkSize:          blockChunkSize,
 	}, nil
 }
 
@@ -69,19 +69,16 @@ func (cs *CsFeeDistributorImplAdapter) ScanDistributionLogUpdatedEvents(
 	}
 
 	// Iterate through block ranges in chunks
-	for current := start; current <= *end; current += cs.BlockChunkSize {
-		chunkEnd := current + cs.BlockChunkSize - 1
-		if chunkEnd > *end {
-			chunkEnd = *end
+	for currentStart := start; currentStart <= *end; currentStart += cs.blockChunkSize {
+		// Determine the end of the current chunk
+		currentEnd := currentStart + cs.blockChunkSize - 1
+		if currentEnd > *end {
+			currentEnd = *end
 		}
 
-		// Ensure chunkEnd is not less than current
-		if chunkEnd <= current {
-			break // Exit the loop to avoid invalid block ranges
-		}
-
-		if err := scanChunk(current, chunkEnd); err != nil {
-			return fmt.Errorf("error scanning block range %d to %d: %w", current, chunkEnd, err)
+		// Scan the current chunk
+		if err := scanChunk(currentStart, currentEnd); err != nil {
+			return fmt.Errorf("error scanning block range %d to %d: %w", currentStart, currentEnd, err)
 		}
 	}
 

--- a/internal/adapters/csFeeDistributorImpl/csFeeDistributorImpl_adapter.go
+++ b/internal/adapters/csFeeDistributorImpl/csFeeDistributorImpl_adapter.go
@@ -14,11 +14,13 @@ import (
 type CsFeeDistributorImplAdapter struct {
 	client                  *ethclient.Client
 	CsFeeDistributorAddress common.Address
+	BlockChunkSize          uint64 // Configurable block chunk size
 }
 
 func NewCsFeeDistributorImplAdapter(
 	wsURL string,
 	csFeeDistributorAddress common.Address,
+	blockChunkSize uint64,
 ) (*CsFeeDistributorImplAdapter, error) {
 	client, err := ethclient.Dial(wsURL)
 	if err != nil {
@@ -28,29 +30,57 @@ func NewCsFeeDistributorImplAdapter(
 	return &CsFeeDistributorImplAdapter{
 		client:                  client,
 		CsFeeDistributorAddress: csFeeDistributorAddress,
+		BlockChunkSize:          blockChunkSize,
 	}, nil
 }
 
-// ScanDistributionLogUpdatedEvents scans the CsFeeDistributor contract for DistributionLogUpdated events.
-func (cs *CsFeeDistributorImplAdapter) ScanDistributionLogUpdatedEvents(ctx context.Context, start uint64, end *uint64, handleDistributionLogUpdated func(*domain.BindingsDistributionLogUpdated) error) error {
+// ScanDistributionLogUpdatedEvents scans the CsFeeDistributor contract for DistributionLogUpdated events in chunks.
+func (cs *CsFeeDistributorImplAdapter) ScanDistributionLogUpdatedEvents(
+	ctx context.Context,
+	start uint64,
+	end *uint64,
+	handleDistributionLogUpdated func(*domain.BindingsDistributionLogUpdated) error,
+) error {
+	if end == nil {
+		return fmt.Errorf("end block cannot be nil")
+	}
+
 	csFeeDistributorContract, err := bindings.NewBindings(cs.CsFeeDistributorAddress, cs.client)
 	if err != nil {
 		return fmt.Errorf("failed to create CsFeeDistributor contract instance: %w", err)
 	}
 
-	// Retrieve DistributionLogUpdated events from the specified block range
-	distributionLogUpdated, err := csFeeDistributorContract.FilterDistributionLogUpdated(&bind.FilterOpts{Context: ctx, Start: start, End: end})
-	if err != nil {
-		return fmt.Errorf("failed to filter DistributionLogUpdated events for block range %d to %v: %w", start, end, err)
-	}
-
-	for distributionLogUpdated.Next() {
-		if err := distributionLogUpdated.Error(); err != nil {
-			return fmt.Errorf("error reading DistributionLogUpdated event: %w", err)
+	// Helper function to scan a chunk
+	scanChunk := func(chunkStart, chunkEnd uint64) error {
+		distributionLogUpdated, err := csFeeDistributorContract.FilterDistributionLogUpdated(
+			&bind.FilterOpts{Context: ctx, Start: chunkStart, End: &chunkEnd},
+		)
+		if err != nil {
+			return fmt.Errorf("failed to filter DistributionLogUpdated events for block range %d to %d: %w", chunkStart, chunkEnd, err)
 		}
 
-		if err := handleDistributionLogUpdated(distributionLogUpdated.Event); err != nil {
-			return fmt.Errorf("failed to handle DistributionLogUpdated event: %w", err)
+		for distributionLogUpdated.Next() {
+			if err := distributionLogUpdated.Error(); err != nil {
+				return fmt.Errorf("error reading DistributionLogUpdated event: %w", err)
+			}
+
+			if err := handleDistributionLogUpdated(distributionLogUpdated.Event); err != nil {
+				return fmt.Errorf("failed to handle DistributionLogUpdated event: %w", err)
+			}
+		}
+
+		return nil
+	}
+
+	// Iterate through block ranges in chunks
+	for current := start; current <= *end; current += cs.BlockChunkSize {
+		chunkEnd := current + cs.BlockChunkSize - 1
+		if chunkEnd > *end {
+			chunkEnd = *end
+		}
+
+		if err := scanChunk(current, chunkEnd); err != nil {
+			return fmt.Errorf("error scanning block range %d to %d: %w", current, chunkEnd, err)
 		}
 	}
 

--- a/internal/adapters/csFeeDistributorImpl/csFeeDistributorImpl_adapter.go
+++ b/internal/adapters/csFeeDistributorImpl/csFeeDistributorImpl_adapter.go
@@ -18,13 +18,13 @@ type CsFeeDistributorImplAdapter struct {
 }
 
 func NewCsFeeDistributorImplAdapter(
-	wsURL string,
+	rpcURL string,
 	csFeeDistributorAddress common.Address,
 	blockChunkSize uint64,
 ) (*CsFeeDistributorImplAdapter, error) {
-	client, err := ethclient.Dial(wsURL)
+	client, err := ethclient.Dial(rpcURL)
 	if err != nil {
-		return nil, fmt.Errorf("failed to connect to Ethereum client at %s: %w", wsURL, err)
+		return nil, fmt.Errorf("failed to connect to Ethereum client at %s: %w", rpcURL, err)
 	}
 
 	return &CsFeeDistributorImplAdapter{

--- a/internal/adapters/csFeeDistributorImpl/csFeeDistributorImpl_adapter.go
+++ b/internal/adapters/csFeeDistributorImpl/csFeeDistributorImpl_adapter.go
@@ -79,6 +79,11 @@ func (cs *CsFeeDistributorImplAdapter) ScanDistributionLogUpdatedEvents(
 			chunkEnd = *end
 		}
 
+		// Ensure chunkEnd is not less than current
+		if chunkEnd <= current {
+			break // Exit the loop to avoid invalid block ranges
+		}
+
 		if err := scanChunk(current, chunkEnd); err != nil {
 			return fmt.Errorf("error scanning block range %d to %d: %w", current, chunkEnd, err)
 		}

--- a/internal/adapters/csFeeDistributorImpl/csFeeDistributorImpl_adapter.go
+++ b/internal/adapters/csFeeDistributorImpl/csFeeDistributorImpl_adapter.go
@@ -12,23 +12,19 @@ import (
 )
 
 type CsFeeDistributorImplAdapter struct {
-	client                  *ethclient.Client
+	rpcClient               *ethclient.Client
 	CsFeeDistributorAddress common.Address
 	BlockChunkSize          uint64 // Configurable block chunk size
 }
 
 func NewCsFeeDistributorImplAdapter(
-	rpcURL string,
+	rpcClient *ethclient.Client,
 	csFeeDistributorAddress common.Address,
 	blockChunkSize uint64,
 ) (*CsFeeDistributorImplAdapter, error) {
-	client, err := ethclient.Dial(rpcURL)
-	if err != nil {
-		return nil, fmt.Errorf("failed to connect to Ethereum client at %s: %w", rpcURL, err)
-	}
 
 	return &CsFeeDistributorImplAdapter{
-		client:                  client,
+		rpcClient:               rpcClient,
 		CsFeeDistributorAddress: csFeeDistributorAddress,
 		BlockChunkSize:          blockChunkSize,
 	}, nil
@@ -45,7 +41,7 @@ func (cs *CsFeeDistributorImplAdapter) ScanDistributionLogUpdatedEvents(
 		return fmt.Errorf("end block cannot be nil")
 	}
 
-	csFeeDistributorContract, err := bindings.NewBindings(cs.CsFeeDistributorAddress, cs.client)
+	csFeeDistributorContract, err := bindings.NewBindings(cs.CsFeeDistributorAddress, cs.rpcClient)
 	if err != nil {
 		return fmt.Errorf("failed to create CsFeeDistributor contract instance: %w", err)
 	}

--- a/internal/adapters/csFeeDistributorImpl/csFeeDistributorImpl_adapter_integration_test.go
+++ b/internal/adapters/csFeeDistributorImpl/csFeeDistributorImpl_adapter_integration_test.go
@@ -18,9 +18,9 @@ import (
 
 // setupCsFeeDistributorImplAdapter initializes VeboAdapter with a mocked StoragePort
 func setupCsFeeDistributorImplAdapter(t *testing.T) (*csfeedistributorimpl.CsFeeDistributorImplAdapter, error) {
-	wsURL := os.Getenv("WS_URL")
-	if wsURL == "" {
-		t.Fatal("WS_URL environment variable not set")
+	rpcURL := os.Getenv("RPC_URL")
+	if rpcURL == "" {
+		t.Fatal("RPC_URL environment variable not set")
 	}
 
 	csfeedistributorimplAddress := common.HexToAddress("0xD7ba648C8F72669C6aE649648B516ec03D07c8ED")
@@ -28,7 +28,7 @@ func setupCsFeeDistributorImplAdapter(t *testing.T) (*csfeedistributorimpl.CsFee
 	blockChunkSize := uint64(10000)
 
 	// Initialize the adapter with the mock storage
-	adapter, err := csfeedistributorimpl.NewCsFeeDistributorImplAdapter(wsURL, csfeedistributorimplAddress, blockChunkSize)
+	adapter, err := csfeedistributorimpl.NewCsFeeDistributorImplAdapter(rpcURL, csfeedistributorimplAddress, blockChunkSize)
 	return adapter, err
 }
 

--- a/internal/adapters/csFeeDistributorImpl/csFeeDistributorImpl_adapter_integration_test.go
+++ b/internal/adapters/csFeeDistributorImpl/csFeeDistributorImpl_adapter_integration_test.go
@@ -25,8 +25,10 @@ func setupCsFeeDistributorImplAdapter(t *testing.T) (*csfeedistributorimpl.CsFee
 
 	csfeedistributorimplAddress := common.HexToAddress("0xD7ba648C8F72669C6aE649648B516ec03D07c8ED")
 
+	blockChunkSize := uint64(10000)
+
 	// Initialize the adapter with the mock storage
-	adapter, err := csfeedistributorimpl.NewCsFeeDistributorImplAdapter(wsURL, csfeedistributorimplAddress)
+	adapter, err := csfeedistributorimpl.NewCsFeeDistributorImplAdapter(wsURL, csfeedistributorimplAddress, blockChunkSize)
 	return adapter, err
 }
 

--- a/internal/adapters/csFeeDistributorImpl/csFeeDistributorImpl_adapter_integration_test.go
+++ b/internal/adapters/csFeeDistributorImpl/csFeeDistributorImpl_adapter_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"lido-events/internal/application/domain"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -22,13 +23,17 @@ func setupCsFeeDistributorImplAdapter(t *testing.T) (*csfeedistributorimpl.CsFee
 	if rpcURL == "" {
 		t.Fatal("RPC_URL environment variable not set")
 	}
+	rpcClient, err := ethclient.Dial(rpcURL)
+	if err != nil {
+		return nil, err
+	}
 
 	csfeedistributorimplAddress := common.HexToAddress("0xD7ba648C8F72669C6aE649648B516ec03D07c8ED")
 
 	blockChunkSize := uint64(10000)
 
 	// Initialize the adapter with the mock storage
-	adapter, err := csfeedistributorimpl.NewCsFeeDistributorImplAdapter(rpcURL, csfeedistributorimplAddress, blockChunkSize)
+	adapter, err := csfeedistributorimpl.NewCsFeeDistributorImplAdapter(rpcClient, csfeedistributorimplAddress, blockChunkSize)
 	return adapter, err
 }
 

--- a/internal/adapters/csModule/csmodule_adapter.go
+++ b/internal/adapters/csModule/csmodule_adapter.go
@@ -221,10 +221,14 @@ func (csma *CsModuleAdapter) ScanNodeOperatorEvents(
 
 	// Iterate through block ranges in chunks
 	for current := start; current <= *end; current += csma.blockChunkSize {
-		// print start and end
 		chunkEnd := current + csma.blockChunkSize - 1
 		if chunkEnd > *end {
 			chunkEnd = *end
+		}
+
+		// Ensure chunkEnd is not less than current
+		if chunkEnd < current {
+			break // Exit the loop to avoid invalid block ranges
 		}
 
 		if err := scanChunk(current, chunkEnd); err != nil {

--- a/internal/adapters/csModule/csmodule_adapter.go
+++ b/internal/adapters/csModule/csmodule_adapter.go
@@ -26,21 +26,12 @@ type CsModuleAdapter struct {
 }
 
 func NewCsModuleAdapter(
-	wsURL string,
-	rpcURL string,
+	websocketClient *ethclient.Client,
+	rpcClient *ethclient.Client,
 	csModuleAddress common.Address,
 	storageAdapter ports.StoragePort,
 	blockChunkSize uint64,
 ) (*CsModuleAdapter, error) {
-	websocketClient, err := ethclient.Dial(wsURL)
-	if err != nil {
-		return nil, err
-	}
-	rpcClient, err := ethclient.Dial(rpcURL)
-	if err != nil {
-		return nil, err
-	}
-
 	initialOperatorIds, err := storageAdapter.GetOperatorIds()
 	if err != nil {
 		return nil, err

--- a/internal/adapters/csModule/csmodule_adapter.go
+++ b/internal/adapters/csModule/csmodule_adapter.go
@@ -21,12 +21,14 @@ type CsModuleAdapter struct {
 	nodeOperatorIds   []*big.Int
 	mu                sync.RWMutex
 	resubscribeSignal chan struct{}
+	blockChunkSize    uint64
 }
 
 func NewCsModuleAdapter(
 	wsURL string,
 	csModuleAddress common.Address,
 	storageAdapter ports.StoragePort,
+	blockChunkSize uint64,
 ) (*CsModuleAdapter, error) {
 	client, err := ethclient.Dial(wsURL)
 	if err != nil {
@@ -44,6 +46,7 @@ func NewCsModuleAdapter(
 		storageAdapter:    storageAdapter,
 		nodeOperatorIds:   initialOperatorIds,
 		resubscribeSignal: make(chan struct{}, 1),
+		blockChunkSize:    blockChunkSize,
 	}
 
 	operatorIdUpdates := storageAdapter.RegisterOperatorIdListener()
@@ -71,100 +74,154 @@ func (csma *CsModuleAdapter) ResubscribeSignal() <-chan struct{} {
 	return csma.resubscribeSignal
 }
 
-// ScanNodeOperatorEvents scans the CsModule contract for NodeOperator events. The CsModule events tracked are: NodeOperatorAdded, NodeOperatorManagerAddressChanged, NodeOperatorRewardAddressChanged
-func (csma *CsModuleAdapter) ScanNodeOperatorEvents(ctx context.Context, address common.Address, start uint64, end *uint64, handleNodeOperatorAddedEvent func(*domain.CsmoduleNodeOperatorAdded, common.Address) error, handleNodeOperatorManagerAddressChangedEvent func(*domain.CsmoduleNodeOperatorManagerAddressChanged, common.Address) error, handleNodeOperatorRewardAddressChangedEvent func(*domain.CsmoduleNodeOperatorRewardAddressChanged, common.Address) error) error {
+// ScanNodeOperatorEvents scans the CsModule contract for NodeOperator events in chunks of blocks.
+func (csma *CsModuleAdapter) ScanNodeOperatorEvents(
+	ctx context.Context,
+	address common.Address,
+	start uint64,
+	end *uint64,
+	handleNodeOperatorAddedEvent func(*domain.CsmoduleNodeOperatorAdded, common.Address) error,
+	handleNodeOperatorManagerAddressChangedEvent func(*domain.CsmoduleNodeOperatorManagerAddressChanged, common.Address) error,
+	handleNodeOperatorRewardAddressChangedEvent func(*domain.CsmoduleNodeOperatorRewardAddressChanged, common.Address) error,
+) error {
+	if end == nil {
+		return fmt.Errorf("end block cannot be nil")
+	}
+
 	csModuleContract, err := bindings.NewCsmodule(csma.csModuleAddress, csma.client)
 	if err != nil {
 		return fmt.Errorf("failed to create CsModule contract instance: %w", err)
 	}
 
-	// Filter for NodeOperatorAdded events qith the address as manager
-	operatorAddedManagerEvents, err := csModuleContract.FilterNodeOperatorAdded(&bind.FilterOpts{Context: ctx, Start: start, End: end}, []*big.Int{}, []common.Address{address}, []common.Address{})
-	if err != nil {
-		return fmt.Errorf("failed to filter NodeOperatorAdded events for block range %d to %v: %w", start, *end, err)
-	}
-	for operatorAddedManagerEvents.Next() {
-		if err := operatorAddedManagerEvents.Error(); err != nil {
-			return err
+	// Helper function to scan a chunk
+	scanChunk := func(chunkStart, chunkEnd uint64) error {
+		// Filter for NodeOperatorAdded events with the address as manager
+		operatorAddedManagerEvents, err := csModuleContract.FilterNodeOperatorAdded(
+			&bind.FilterOpts{Context: ctx, Start: chunkStart, End: &chunkEnd},
+			[]*big.Int{},              // No filter for `nodeOperatorId`
+			[]common.Address{address}, // Address as manager
+			[]common.Address{},        // No filter for rewardAddress
+		)
+		if err != nil {
+			return fmt.Errorf("failed to filter NodeOperatorAdded (manager) events for block range %d to %d: %w", chunkStart, chunkEnd, err)
+		}
+		for operatorAddedManagerEvents.Next() {
+			if err := operatorAddedManagerEvents.Error(); err != nil {
+				return err
+			}
+			if err := handleNodeOperatorAddedEvent(operatorAddedManagerEvents.Event, address); err != nil {
+				return err
+			}
 		}
 
-		if err := handleNodeOperatorAddedEvent(operatorAddedManagerEvents.Event, address); err != nil {
-			return err
+		// Filter for NodeOperatorAdded events with the address as reward
+		operatorAddedRewardEvents, err := csModuleContract.FilterNodeOperatorAdded(
+			&bind.FilterOpts{Context: ctx, Start: chunkStart, End: &chunkEnd},
+			[]*big.Int{},              // No filter for `nodeOperatorId`
+			[]common.Address{},        // No filter for managerAddress
+			[]common.Address{address}, // Address as reward
+		)
+		if err != nil {
+			return fmt.Errorf("failed to filter NodeOperatorAdded (reward) events for block range %d to %d: %w", chunkStart, chunkEnd, err)
 		}
-	}
-
-	// Filter for NodeOperatorAdded events with the address as reward
-	operatorAddedRewardEvents, err := csModuleContract.FilterNodeOperatorAdded(&bind.FilterOpts{Context: ctx, Start: start, End: end}, []*big.Int{}, []common.Address{}, []common.Address{address})
-	if err != nil {
-		return fmt.Errorf("failed to filter NodeOperatorAdded events for block range %d to %v: %w", start, *end, err)
-	}
-	for operatorAddedRewardEvents.Next() {
-		if err := operatorAddedRewardEvents.Error(); err != nil {
-			return err
-		}
-
-		if err := handleNodeOperatorAddedEvent(operatorAddedRewardEvents.Event, address); err != nil {
-			return err
-		}
-	}
-
-	// Filter for NodeOperatorManagerAddressChanged events with the address as manager
-	operatorManagerManagerChangedEvents, err := csModuleContract.FilterNodeOperatorManagerAddressChanged(&bind.FilterOpts{Context: ctx, Start: start, End: end}, []*big.Int{}, []common.Address{address}, []common.Address{})
-	if err != nil {
-		return fmt.Errorf("failed to filter NodeOperatorManagerAddressChanged events for block range %d to %v: %w", start, *end, err)
-	}
-	for operatorManagerManagerChangedEvents.Next() {
-		if err := operatorManagerManagerChangedEvents.Error(); err != nil {
-			return err
+		for operatorAddedRewardEvents.Next() {
+			if err := operatorAddedRewardEvents.Error(); err != nil {
+				return err
+			}
+			if err := handleNodeOperatorAddedEvent(operatorAddedRewardEvents.Event, address); err != nil {
+				return err
+			}
 		}
 
-		if err := handleNodeOperatorManagerAddressChangedEvent(operatorManagerManagerChangedEvents.Event, address); err != nil {
-			return err
+		// Filter for NodeOperatorManagerAddressChanged events with the address as manager
+		operatorManagerChangedManagerEvents, err := csModuleContract.FilterNodeOperatorManagerAddressChanged(
+			&bind.FilterOpts{Context: ctx, Start: chunkStart, End: &chunkEnd},
+			[]*big.Int{},              // No filter for `nodeOperatorId`
+			[]common.Address{address}, // Address as manager
+			[]common.Address{},        // No filter for rewardAddress
+		)
+		if err != nil {
+			return fmt.Errorf("failed to filter NodeOperatorManagerAddressChanged (manager) events for block range %d to %d: %w", chunkStart, chunkEnd, err)
 		}
-	}
-
-	// Filter for NodeOperatorManagerAddressChanged events with the address as reward
-	operatorManagerRewardChangedEvents, err := csModuleContract.FilterNodeOperatorManagerAddressChanged(&bind.FilterOpts{Context: ctx, Start: start, End: end}, []*big.Int{}, []common.Address{}, []common.Address{address})
-	if err != nil {
-		return fmt.Errorf("failed to filter NodeOperatorManagerAddressChanged events for block range %d to %v: %w", start, *end, err)
-	}
-	for operatorManagerRewardChangedEvents.Next() {
-		if err := operatorManagerRewardChangedEvents.Error(); err != nil {
-			return err
-		}
-
-		if err := handleNodeOperatorManagerAddressChangedEvent(operatorManagerRewardChangedEvents.Event, address); err != nil {
-			return err
-		}
-	}
-
-	// Filter for NodeOperatorRewardAddressChanged events with the address as manager
-	operatorRewardManagerChangedEvents, err := csModuleContract.FilterNodeOperatorRewardAddressChanged(&bind.FilterOpts{Context: ctx, Start: start, End: end}, []*big.Int{}, []common.Address{address}, []common.Address{})
-	if err != nil {
-		return fmt.Errorf("failed to filter NodeOperatorRewardAddressChanged events for block range %d to %v: %w", start, *end, err)
-	}
-	for operatorRewardManagerChangedEvents.Next() {
-		if err := operatorRewardManagerChangedEvents.Error(); err != nil {
-			return err
+		for operatorManagerChangedManagerEvents.Next() {
+			if err := operatorManagerChangedManagerEvents.Error(); err != nil {
+				return err
+			}
+			if err := handleNodeOperatorManagerAddressChangedEvent(operatorManagerChangedManagerEvents.Event, address); err != nil {
+				return err
+			}
 		}
 
-		if err := handleNodeOperatorRewardAddressChangedEvent(operatorRewardManagerChangedEvents.Event, address); err != nil {
-			return err
+		// Filter for NodeOperatorManagerAddressChanged events with the address as reward
+		operatorManagerChangedRewardEvents, err := csModuleContract.FilterNodeOperatorManagerAddressChanged(
+			&bind.FilterOpts{Context: ctx, Start: chunkStart, End: &chunkEnd},
+			[]*big.Int{},              // No filter for `nodeOperatorId`
+			[]common.Address{},        // No filter for managerAddress
+			[]common.Address{address}, // Address as reward
+		)
+		if err != nil {
+			return fmt.Errorf("failed to filter NodeOperatorManagerAddressChanged (reward) events for block range %d to %d: %w", chunkStart, chunkEnd, err)
 		}
+		for operatorManagerChangedRewardEvents.Next() {
+			if err := operatorManagerChangedRewardEvents.Error(); err != nil {
+				return err
+			}
+			if err := handleNodeOperatorManagerAddressChangedEvent(operatorManagerChangedRewardEvents.Event, address); err != nil {
+				return err
+			}
+		}
+
+		// Filter for NodeOperatorRewardAddressChanged events with the address as manager
+		operatorRewardChangedManagerEvents, err := csModuleContract.FilterNodeOperatorRewardAddressChanged(
+			&bind.FilterOpts{Context: ctx, Start: chunkStart, End: &chunkEnd},
+			[]*big.Int{},              // No filter for `nodeOperatorId`
+			[]common.Address{address}, // Address as manager
+			[]common.Address{},        // No filter for rewardAddress
+		)
+		if err != nil {
+			return fmt.Errorf("failed to filter NodeOperatorRewardAddressChanged (manager) events for block range %d to %d: %w", chunkStart, chunkEnd, err)
+		}
+		for operatorRewardChangedManagerEvents.Next() {
+			if err := operatorRewardChangedManagerEvents.Error(); err != nil {
+				return err
+			}
+			if err := handleNodeOperatorRewardAddressChangedEvent(operatorRewardChangedManagerEvents.Event, address); err != nil {
+				return err
+			}
+		}
+
+		// Filter for NodeOperatorRewardAddressChanged events with the address as reward
+		operatorRewardChangedRewardEvents, err := csModuleContract.FilterNodeOperatorRewardAddressChanged(
+			&bind.FilterOpts{Context: ctx, Start: chunkStart, End: &chunkEnd},
+			[]*big.Int{},              // No filter for `nodeOperatorId`
+			[]common.Address{},        // No filter for managerAddress
+			[]common.Address{address}, // Address as reward
+		)
+		if err != nil {
+			return fmt.Errorf("failed to filter NodeOperatorRewardAddressChanged (reward) events for block range %d to %d: %w", chunkStart, chunkEnd, err)
+		}
+		for operatorRewardChangedRewardEvents.Next() {
+			if err := operatorRewardChangedRewardEvents.Error(); err != nil {
+				return err
+			}
+			if err := handleNodeOperatorRewardAddressChangedEvent(operatorRewardChangedRewardEvents.Event, address); err != nil {
+				return err
+			}
+		}
+
+		return nil
 	}
 
-	// Filter for NodeOperatorRewardAddressChanged events with the address as manager
-	operatorRewardRewardChangedEvents, err := csModuleContract.FilterNodeOperatorRewardAddressChanged(&bind.FilterOpts{Context: ctx, Start: start, End: end}, []*big.Int{}, []common.Address{}, []common.Address{address})
-	if err != nil {
-		return fmt.Errorf("failed to filter NodeOperatorRewardAddressChanged events for block range %d to %v: %w", start, *end, err)
-	}
-	for operatorRewardRewardChangedEvents.Next() {
-		if err := operatorRewardRewardChangedEvents.Error(); err != nil {
-			return err
+	// Iterate through block ranges in chunks
+	for current := start; current <= *end; current += csma.blockChunkSize {
+		// print start and end
+		chunkEnd := current + csma.blockChunkSize - 1
+		if chunkEnd > *end {
+			chunkEnd = *end
 		}
 
-		if err := handleNodeOperatorRewardAddressChangedEvent(operatorRewardRewardChangedEvents.Event, address); err != nil {
-			return err
+		if err := scanChunk(current, chunkEnd); err != nil {
+			return fmt.Errorf("error scanning block range %d to %d: %w", current, chunkEnd, err)
 		}
 	}
 

--- a/internal/adapters/csModule/csmodule_adapter.go
+++ b/internal/adapters/csModule/csmodule_adapter.go
@@ -227,7 +227,7 @@ func (csma *CsModuleAdapter) ScanNodeOperatorEvents(
 		}
 
 		// Ensure chunkEnd is not less than current
-		if chunkEnd < current {
+		if chunkEnd <= current {
 			break // Exit the loop to avoid invalid block ranges
 		}
 

--- a/internal/adapters/csModule/csmodule_adapter.go
+++ b/internal/adapters/csModule/csmodule_adapter.go
@@ -211,19 +211,16 @@ func (csma *CsModuleAdapter) ScanNodeOperatorEvents(
 	}
 
 	// Iterate through block ranges in chunks
-	for current := start; current <= *end; current += csma.blockChunkSize {
-		chunkEnd := current + csma.blockChunkSize - 1
-		if chunkEnd > *end {
-			chunkEnd = *end
+	for currentStart := start; currentStart <= *end; currentStart += csma.blockChunkSize {
+		// Determine the end of the current chunk
+		currentEnd := currentStart + csma.blockChunkSize - 1
+		if currentEnd > *end {
+			currentEnd = *end
 		}
 
-		// Ensure chunkEnd is not less than current
-		if chunkEnd <= current {
-			break // Exit the loop to avoid invalid block ranges
-		}
-
-		if err := scanChunk(current, chunkEnd); err != nil {
-			return fmt.Errorf("error scanning block range %d to %d: %w", current, chunkEnd, err)
+		// Scan the current chunk
+		if err := scanChunk(currentStart, currentEnd); err != nil {
+			return fmt.Errorf("error scanning block range %d to %d: %w", currentStart, currentEnd, err)
 		}
 	}
 

--- a/internal/adapters/csModule/csmodule_adapter_test.go
+++ b/internal/adapters/csModule/csmodule_adapter_test.go
@@ -38,10 +38,11 @@ func setupCsModuleAdapter(t *testing.T) (*csmodule.CsModuleAdapter, *mocks.MockS
 	operatorIdChan := make(chan []*big.Int, 1)
 	mockStorage.On("RegisterOperatorIdListener").Return(operatorIdChan)
 
-	csModuleAddress := common.HexToAddress("0x4562c3e63c2e586cD1651B958C22F88135aCAd4f")
+	csModuleAddress := common.HexToAddress("0xdA7dE2ECdDfccC6c3AF10108Db212ACBBf9EA83F")
+	blockChunkSize := uint64(10000)
 
 	// Initialize the adapter with the mock storage
-	adapter, err := csmodule.NewCsModuleAdapter(wsURL, csModuleAddress, mockStorage)
+	adapter, err := csmodule.NewCsModuleAdapter(wsURL, csModuleAddress, mockStorage, blockChunkSize)
 	return adapter, mockStorage, err
 }
 
@@ -52,10 +53,10 @@ func TestScanNodeOperatorEventsIntegration(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Set the start and end blocks for the scan
-	start := uint64(3003264)
-	end := uint64(3144706)
+	start := uint64(20935463)
+	end := uint64(21657327)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 260*time.Second)
 	defer cancel()
 
 	// Map to store and verify events found during the scan
@@ -73,7 +74,7 @@ func TestScanNodeOperatorEventsIntegration(t *testing.T) {
 	t.Log("Scanning for NodeOperator events...")
 	// print start and end
 	t.Logf("Start block: %d, End block: %d", start, end)
-	err = adapter.ScanNodeOperatorEvents(ctx, common.HexToAddress("0x913f440ed5ec7ccbbab7e72ae3803bdfea95606a"), start, &end,
+	err = adapter.ScanNodeOperatorEvents(ctx, common.HexToAddress("0x18a2869554df268828bc366fb5333df89c9c2b7b"), start, &end,
 		func(event *domain.CsmoduleNodeOperatorAdded, address common.Address) error {
 			foundEvents.NodeOperatorAdded[event.NodeOperatorId.String()] = struct{}{}
 			t.Logf("NodeOperatorAdded: NodeOperatorId=%s, ManagerAddress=%s, RewardAddress=%s, BlockNumber=%d",

--- a/internal/adapters/csModule/csmodule_adapter_test.go
+++ b/internal/adapters/csModule/csmodule_adapter_test.go
@@ -24,6 +24,11 @@ func setupCsModuleAdapter(t *testing.T) (*csmodule.CsModuleAdapter, *mocks.MockS
 		t.Fatal("WS_URL environment variable not set")
 	}
 
+	rpcURL := os.Getenv("RPC_URL")
+	if rpcURL == "" {
+		t.Fatal("RPC_URL environment variable not set")
+	}
+
 	// Create the mock StoragePort
 	mockStorage := new(mocks.MockStoragePort)
 
@@ -42,7 +47,7 @@ func setupCsModuleAdapter(t *testing.T) (*csmodule.CsModuleAdapter, *mocks.MockS
 	blockChunkSize := uint64(10000)
 
 	// Initialize the adapter with the mock storage
-	adapter, err := csmodule.NewCsModuleAdapter(wsURL, csModuleAddress, mockStorage, blockChunkSize)
+	adapter, err := csmodule.NewCsModuleAdapter(wsURL, rpcURL, csModuleAddress, mockStorage, blockChunkSize)
 	return adapter, mockStorage, err
 }
 

--- a/internal/adapters/csModule/csmodule_adapter_test.go
+++ b/internal/adapters/csModule/csmodule_adapter_test.go
@@ -5,6 +5,7 @@ package csmodule_test
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"os"
 	"testing"
@@ -15,6 +16,7 @@ import (
 	"lido-events/internal/mocks"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -27,6 +29,16 @@ func setupCsModuleAdapter(t *testing.T) (*csmodule.CsModuleAdapter, *mocks.MockS
 	rpcURL := os.Getenv("RPC_URL")
 	if rpcURL == "" {
 		t.Fatal("RPC_URL environment variable not set")
+	}
+
+	// Initiate the clients
+	rpcClient, err := ethclient.Dial(rpcURL)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to connect to Ethereum client at %s: %w", rpcURL, err)
+	}
+	wsClient, err := ethclient.Dial(wsURL)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to connect to Ethereum client at %s: %w", wsURL, err)
 	}
 
 	// Create the mock StoragePort
@@ -47,7 +59,7 @@ func setupCsModuleAdapter(t *testing.T) (*csmodule.CsModuleAdapter, *mocks.MockS
 	blockChunkSize := uint64(10000)
 
 	// Initialize the adapter with the mock storage
-	adapter, err := csmodule.NewCsModuleAdapter(wsURL, rpcURL, csModuleAddress, mockStorage, blockChunkSize)
+	adapter, err := csmodule.NewCsModuleAdapter(wsClient, rpcClient, csModuleAddress, mockStorage, blockChunkSize)
 	return adapter, mockStorage, err
 }
 

--- a/internal/adapters/relaysAllowed/relaysAllowed_adapter.go
+++ b/internal/adapters/relaysAllowed/relaysAllowed_adapter.go
@@ -13,25 +13,21 @@ import (
 )
 
 type RelaysAllowedAdapter struct {
-	Client                         *ethclient.Client
+	RpcClient                      *ethclient.Client
 	MevBoostRelaysAllowListAddress common.Address
 	DappmanagerUrl                 string
 	MevBoostDnpName                string
 }
 
 func NewRelaysAllowedAdapter(
-	wsURL string,
+	rpcClient *ethclient.Client,
 	mevBoostRelaysAllowListAddress common.Address,
 	dappmanagerUrl string,
 	mevBoostDnpName string,
 ) (*RelaysAllowedAdapter, error) {
-	client, err := ethclient.Dial(wsURL)
-	if err != nil {
-		return nil, fmt.Errorf("failed to connect to Ethereum client at %s: %w", wsURL, err)
-	}
 
 	return &RelaysAllowedAdapter{
-		client,
+		rpcClient,
 		mevBoostRelaysAllowListAddress,
 		dappmanagerUrl,
 		mevBoostDnpName,
@@ -40,7 +36,7 @@ func NewRelaysAllowedAdapter(
 
 // getRelaysAllowList fetches relays allow list from the SC
 func (mev *RelaysAllowedAdapter) GetRelaysAllowList(ctx context.Context) ([]domain.RelayAllowed, error) {
-	relaysAllowListContract, err := bindings.NewBindings(mev.MevBoostRelaysAllowListAddress, mev.Client)
+	relaysAllowListContract, err := bindings.NewBindings(mev.MevBoostRelaysAllowListAddress, mev.RpcClient)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create MevBoostRelaysAllowList contract instance: %w", err)
 	}

--- a/internal/adapters/vebo/vebo_adapter.go
+++ b/internal/adapters/vebo/vebo_adapter.go
@@ -100,6 +100,11 @@ func (va *VeboAdapter) ScanVeboValidatorExitRequestEvent(
 			chunkEnd = *end
 		}
 
+		// Ensure chunkEnd is not less than current
+		if chunkEnd <= current {
+			break // Exit the loop to avoid invalid block ranges
+		}
+
 		if err := scanChunk(current, chunkEnd); err != nil {
 			return fmt.Errorf("error scanning block range %d to %d: %w", current, chunkEnd, err)
 		}

--- a/internal/adapters/vebo/vebo_adapter.go
+++ b/internal/adapters/vebo/vebo_adapter.go
@@ -18,7 +18,7 @@ type VeboAdapter struct {
 	RpcClient      *ethclient.Client
 	VeboAddress    common.Address
 	StorageAdapter ports.StoragePort
-	BlockChunkSize uint64
+	blockChunkSize uint64
 }
 
 func NewVeboAdapter(
@@ -33,7 +33,7 @@ func NewVeboAdapter(
 		RpcClient:      rpcClient,
 		VeboAddress:    veboAddress,
 		StorageAdapter: storageAdapter,
-		BlockChunkSize: blockChunkSize,
+		blockChunkSize: blockChunkSize,
 	}, nil
 }
 
@@ -84,20 +84,17 @@ func (va *VeboAdapter) ScanVeboValidatorExitRequestEvent(
 		return nil
 	}
 
-	// Iterate through the block range in chunks
-	for current := start; current <= *end; current += va.BlockChunkSize {
-		chunkEnd := current + va.BlockChunkSize - 1
-		if chunkEnd > *end {
-			chunkEnd = *end
+	// Iterate through block ranges in chunks
+	for currentStart := start; currentStart <= *end; currentStart += va.blockChunkSize {
+		// Determine the end of the current chunk
+		currentEnd := currentStart + va.blockChunkSize - 1
+		if currentEnd > *end {
+			currentEnd = *end
 		}
 
-		// Ensure chunkEnd is not less than current
-		if chunkEnd <= current {
-			break // Exit the loop to avoid invalid block ranges
-		}
-
-		if err := scanChunk(current, chunkEnd); err != nil {
-			return fmt.Errorf("error scanning block range %d to %d: %w", current, chunkEnd, err)
+		// Scan the current chunk
+		if err := scanChunk(currentStart, currentEnd); err != nil {
+			return fmt.Errorf("error scanning block range %d to %d: %w", currentStart, currentEnd, err)
 		}
 	}
 

--- a/internal/adapters/vebo/vebo_adapter.go
+++ b/internal/adapters/vebo/vebo_adapter.go
@@ -17,12 +17,14 @@ type VeboAdapter struct {
 	Client         *ethclient.Client
 	VeboAddress    common.Address
 	StorageAdapter ports.StoragePort
+	BlockChunkSize uint64
 }
 
 func NewVeboAdapter(
 	wsURL string,
 	veboAddress common.Address,
 	storageAdapter ports.StoragePort,
+	blockChunkSize uint64,
 ) (*VeboAdapter, error) {
 	client, err := ethclient.Dial(wsURL)
 	if err != nil {
@@ -30,38 +32,69 @@ func NewVeboAdapter(
 	}
 
 	return &VeboAdapter{
-		client,
-		veboAddress,
-		storageAdapter,
+		Client:         client,
+		VeboAddress:    veboAddress,
+		StorageAdapter: storageAdapter,
+		BlockChunkSize: blockChunkSize,
 	}, nil
 }
 
-// ScanVeboValidatorExitRequestEvent scans the Vebo contract for ValidatorExitRequest events.
-func (va *VeboAdapter) ScanVeboValidatorExitRequestEvent(ctx context.Context, start uint64, end *uint64, handleValidatorExitRequestEvent func(*domain.VeboValidatorExitRequest) error) error {
+// ScanVeboValidatorExitRequestEvent scans the Vebo contract for ValidatorExitRequest events in chunks.
+func (va *VeboAdapter) ScanVeboValidatorExitRequestEvent(
+	ctx context.Context,
+	start uint64,
+	end *uint64,
+	handleValidatorExitRequestEvent func(*domain.VeboValidatorExitRequest) error,
+) error {
+	if end == nil {
+		return fmt.Errorf("end block cannot be nil")
+	}
+
 	veboContract, err := bindings.NewVebo(va.VeboAddress, va.Client)
 	if err != nil {
 		return fmt.Errorf("failed to create Vebo contract instance: %w", err)
 	}
 
-	// Get operator ids
+	// Get operator IDs
 	operatorIds, err := va.StorageAdapter.GetOperatorIds()
 	if err != nil {
 		return fmt.Errorf("failed to retrieve operator IDs from storage: %w", err)
 	}
 
-	// Filter for ValidatorExitRequest events
-	validatorExitRequestEvents, err := veboContract.FilterValidatorExitRequest(&bind.FilterOpts{Context: ctx, Start: start, End: end}, []*big.Int{}, operatorIds, []*big.Int{})
-	if err != nil {
-		return fmt.Errorf("failed to filter ValidatorExitRequest events: %w", err)
-	}
-
-	for validatorExitRequestEvents.Next() {
-		if err := validatorExitRequestEvents.Error(); err != nil {
-			return fmt.Errorf("error reading ValidatorExitRequest event: %w", err)
+	// Helper function to scan a chunk
+	scanChunk := func(chunkStart, chunkEnd uint64) error {
+		validatorExitRequestEvents, err := veboContract.FilterValidatorExitRequest(
+			&bind.FilterOpts{Context: ctx, Start: chunkStart, End: &chunkEnd},
+			[]*big.Int{}, // No filter for `stakingModuleId`
+			operatorIds,  // Operator IDs filter
+			[]*big.Int{}, // No filter for `validatorIndex`
+		)
+		if err != nil {
+			return fmt.Errorf("failed to filter ValidatorExitRequest events for block range %d to %d: %w", chunkStart, chunkEnd, err)
 		}
 
-		if err := handleValidatorExitRequestEvent(validatorExitRequestEvents.Event); err != nil {
-			return fmt.Errorf("failed to handle ValidatorExitRequest event: %w", err)
+		for validatorExitRequestEvents.Next() {
+			if err := validatorExitRequestEvents.Error(); err != nil {
+				return fmt.Errorf("error reading ValidatorExitRequest event: %w", err)
+			}
+
+			if err := handleValidatorExitRequestEvent(validatorExitRequestEvents.Event); err != nil {
+				return fmt.Errorf("failed to handle ValidatorExitRequest event: %w", err)
+			}
+		}
+
+		return nil
+	}
+
+	// Iterate through the block range in chunks
+	for current := start; current <= *end; current += va.BlockChunkSize {
+		chunkEnd := current + va.BlockChunkSize - 1
+		if chunkEnd > *end {
+			chunkEnd = *end
+		}
+
+		if err := scanChunk(current, chunkEnd); err != nil {
+			return fmt.Errorf("error scanning block range %d to %d: %w", current, chunkEnd, err)
 		}
 	}
 

--- a/internal/adapters/vebo/vebo_adapter.go
+++ b/internal/adapters/vebo/vebo_adapter.go
@@ -14,29 +14,20 @@ import (
 )
 
 type VeboAdapter struct {
-	RpcClient      *ethclient.Client
 	WsClient       *ethclient.Client
+	RpcClient      *ethclient.Client
 	VeboAddress    common.Address
 	StorageAdapter ports.StoragePort
 	BlockChunkSize uint64
 }
 
 func NewVeboAdapter(
-	wsURL string,
-	rpcURL string,
+	wsClient *ethclient.Client,
+	rpcClient *ethclient.Client,
 	veboAddress common.Address,
 	storageAdapter ports.StoragePort,
 	blockChunkSize uint64,
 ) (*VeboAdapter, error) {
-	wsClient, err := ethclient.Dial(wsURL)
-	if err != nil {
-		return nil, fmt.Errorf("failed to connect to Ethereum client at %s: %w", wsURL, err)
-	}
-	rpcClient, err := ethclient.Dial(rpcURL)
-	if err != nil {
-		return nil, fmt.Errorf("failed to connect to Ethereum client at %s: %w", rpcURL, err)
-	}
-
 	return &VeboAdapter{
 		WsClient:       wsClient,
 		RpcClient:      rpcClient,

--- a/internal/adapters/vebo/vebo_adapter_integration_test.go
+++ b/internal/adapters/vebo/vebo_adapter_integration_test.go
@@ -33,8 +33,10 @@ func setupVeboAdapter(t *testing.T) (*vebo.VeboAdapter, *mocks.MockStoragePort, 
 
 	veboAddress := common.HexToAddress("0xffDDF7025410412deaa05E3E1cE68FE53208afcb")
 
+	blockChunkSize := uint64(10000)
+
 	// Initialize the adapter with the mock storage
-	adapter, err := vebo.NewVeboAdapter(wsURL, veboAddress, mockStorage)
+	adapter, err := vebo.NewVeboAdapter(wsURL, veboAddress, mockStorage, blockChunkSize)
 	return adapter, mockStorage, err
 }
 

--- a/internal/adapters/vebo/vebo_adapter_integration_test.go
+++ b/internal/adapters/vebo/vebo_adapter_integration_test.go
@@ -15,6 +15,7 @@ import (
 	"lido-events/internal/mocks"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -24,10 +25,18 @@ func setupVeboAdapter(t *testing.T) (*vebo.VeboAdapter, *mocks.MockStoragePort, 
 	if wsURL == "" {
 		t.Fatal("WS_URL environment variable not set")
 	}
+	wsClient, err := ethclient.Dial(wsURL)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	rpcURL := os.Getenv("RPC_URL")
 	if rpcURL == "" {
 		t.Fatal("RPC_URL environment variable not set")
+	}
+	rpcClient, err := ethclient.Dial(rpcURL)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	// Create the mock StoragePort
@@ -41,7 +50,7 @@ func setupVeboAdapter(t *testing.T) (*vebo.VeboAdapter, *mocks.MockStoragePort, 
 	blockChunkSize := uint64(10000)
 
 	// Initialize the adapter with the mock storage
-	adapter, err := vebo.NewVeboAdapter(wsURL, rpcURL, veboAddress, mockStorage, blockChunkSize)
+	adapter, err := vebo.NewVeboAdapter(wsClient, rpcClient, veboAddress, mockStorage, blockChunkSize)
 	return adapter, mockStorage, err
 }
 

--- a/internal/adapters/vebo/vebo_adapter_integration_test.go
+++ b/internal/adapters/vebo/vebo_adapter_integration_test.go
@@ -25,6 +25,11 @@ func setupVeboAdapter(t *testing.T) (*vebo.VeboAdapter, *mocks.MockStoragePort, 
 		t.Fatal("WS_URL environment variable not set")
 	}
 
+	rpcURL := os.Getenv("RPC_URL")
+	if rpcURL == "" {
+		t.Fatal("RPC_URL environment variable not set")
+	}
+
 	// Create the mock StoragePort
 	mockStorage := new(mocks.MockStoragePort)
 
@@ -36,7 +41,7 @@ func setupVeboAdapter(t *testing.T) (*vebo.VeboAdapter, *mocks.MockStoragePort, 
 	blockChunkSize := uint64(10000)
 
 	// Initialize the adapter with the mock storage
-	adapter, err := vebo.NewVeboAdapter(wsURL, veboAddress, mockStorage, blockChunkSize)
+	adapter, err := vebo.NewVeboAdapter(wsURL, rpcURL, veboAddress, mockStorage, blockChunkSize)
 	return adapter, mockStorage, err
 }
 

--- a/internal/adapters/vebo/vebo_adapter_integration_test.go
+++ b/internal/adapters/vebo/vebo_adapter_integration_test.go
@@ -42,6 +42,7 @@ func setupVeboAdapter(t *testing.T) (*vebo.VeboAdapter, *mocks.MockStoragePort, 
 
 // TestScanVeboValidatorExitRequestEventIntegration tests scanning for ValidatorExitRequest events with mocked data
 func TestScanVeboValidatorExitRequestEventIntegration(t *testing.T) {
+	t.Skip()
 	adapter, mockStorage, err := setupVeboAdapter(t)
 	assert.NoError(t, err)
 

--- a/internal/application/services/csModuleEventsScanner.go
+++ b/internal/application/services/csModuleEventsScanner.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"fmt"
 	"lido-events/internal/application/domain"
 	"lido-events/internal/application/ports"
 	"lido-events/internal/logger"
@@ -29,27 +30,23 @@ func NewCsModuleEventsScanner(storagePort ports.StoragePort, executionPort ports
 	}
 }
 
-func (cs *CsModuleEventsScanner) ScanAddressEvents(ctx context.Context, address common.Address) {
+func (cs *CsModuleEventsScanner) ScanAddressEvents(ctx context.Context, address common.Address) error {
 	isSyncing, err := cs.executionPort.IsSyncing()
 	if err != nil {
-		logger.ErrorWithPrefix(cs.servicePrefix, "Error checking if node is syncing: %v", err)
-		return
+		return fmt.Errorf("error checking if node is syncing: %w", err)
 	}
 
 	if isSyncing {
-		logger.InfoWithPrefix(cs.servicePrefix, "Node is syncing, skipping CsModule events scan")
-		return
+		return fmt.Errorf("node is syncing")
 	}
 
 	// Skip if tx receipt not found. This means that the node does not store log receipts and there are no logs at all
 	receiptExists, err := cs.executionPort.GetTransactionReceiptExists(cs.csModuleTxReceipt)
 	if err != nil {
-		logger.ErrorWithPrefix(cs.servicePrefix, "Error checking if transaction receipt exists: %v", err)
-		return
+		return fmt.Errorf("error checking if transaction receipt exists: %w", err)
 	}
 	if !receiptExists {
-		logger.WarnWithPrefix(cs.servicePrefix, "Transaction receipt for csModule deployment not found. This probably means your node does not store log receipts, check out the official documentation of your node and configure the node to store them. Skipping CsModule events scan")
-		return
+		return fmt.Errorf("transaction receipt for csModule deployment not found")
 	}
 
 	start, err := cs.storagePort.GetAddressLastProcessedBlock(address)
@@ -65,14 +62,12 @@ func (cs *CsModuleEventsScanner) ScanAddressEvents(ctx context.Context, address 
 
 	end, err := cs.executionPort.GetMostRecentBlockNumber()
 	if err != nil {
-		logger.ErrorWithPrefix(cs.servicePrefix, "Failed to get most recent block number: %v", err)
-		return
+		return fmt.Errorf("error getting most recent block number: %w", err)
 	}
 
 	// return if start block is greater than end block
 	if start > end {
-		logger.WarnWithPrefix(cs.servicePrefix, "Start block is greater than end block, skipping CsModule events scan")
-		return
+		return fmt.Errorf("start block is greater than end block")
 	}
 
 	if err := cs.csModulePort.ScanNodeOperatorEvents(
@@ -84,16 +79,15 @@ func (cs *CsModuleEventsScanner) ScanAddressEvents(ctx context.Context, address 
 		cs.HandleNodeOperatorManagerAddressChangedEvent,
 		cs.HandleNodeOperatorRewardAddressChangedEvent,
 	); err != nil {
-		logger.ErrorWithPrefix(cs.servicePrefix, "Error scanning NodeOperator events: %v", err)
-		return
+		return fmt.Errorf("error scanning NodeOperator events: %w", err)
 	}
 
 	if err := cs.storagePort.SaveAddressLastProcessedBlock(address, end); err != nil {
-		logger.ErrorWithPrefix(cs.servicePrefix, "Error saving last processed block: %v", err)
-		return
+		return fmt.Errorf("error saving last processed block: %w", err)
 	}
 
 	logger.DebugWithPrefix(cs.servicePrefix, "Address events scan completed")
+	return nil
 }
 
 func (cs *CsModuleEventsScanner) HandleNodeOperatorAddedEvent(event *domain.CsmoduleNodeOperatorAdded, address common.Address) error {

--- a/internal/application/services/csModuleEventsScanner.go
+++ b/internal/application/services/csModuleEventsScanner.go
@@ -92,6 +92,8 @@ func (cs *CsModuleEventsScanner) ScanAddressEvents(ctx context.Context, address 
 		logger.ErrorWithPrefix(cs.servicePrefix, "Error saving last processed block: %v", err)
 		return
 	}
+
+	logger.DebugWithPrefix(cs.servicePrefix, "Address events scan completed")
 }
 
 func (cs *CsModuleEventsScanner) HandleNodeOperatorAddedEvent(event *domain.CsmoduleNodeOperatorAdded, address common.Address) error {

--- a/internal/application/services/csModuleEventsScanner.go
+++ b/internal/application/services/csModuleEventsScanner.go
@@ -69,6 +69,12 @@ func (cs *CsModuleEventsScanner) ScanAddressEvents(ctx context.Context, address 
 		return
 	}
 
+	// return if start block is greater than end block
+	if start > end {
+		logger.WarnWithPrefix(cs.servicePrefix, "Start block is greater than end block, skipping CsModule events scan")
+		return
+	}
+
 	if err := cs.csModulePort.ScanNodeOperatorEvents(
 		ctx,
 		address,

--- a/internal/config/config_loader.go
+++ b/internal/config/config_loader.go
@@ -223,7 +223,8 @@ func LoadNetworkConfig() (Config, error) {
 			CSModuleTxReceipt:               common.HexToHash("0xf5330dbcf09885ed145c4435e356b5d8a10054751bb8009d3a2605d476ac173f"),
 			LidoKeysApiUrl:                  "https://keys-api.lido.fi",
 			ProxyApiPort:                    proxyApiPort,
-			MinGenesisTime:                  blockChunkSize,
+			MinGenesisTime:                  uint64(1606824023),
+			BlockChunkSize:                  blockChunkSize,
 		}
 	default:
 		logger.Fatal("Unknown network: %s", network)

--- a/internal/config/config_loader.go
+++ b/internal/config/config_loader.go
@@ -49,6 +49,7 @@ type Config struct {
 
 	// Blockchain
 	MinGenesisTime uint64
+	BlockChunkSize uint64
 }
 
 // Helper function to parse and validate CORS from environment variable
@@ -128,6 +129,16 @@ func LoadNetworkConfig() (Config, error) {
 	if logLevel == "" {
 		logLevel = "INFO" // Default log level
 	}
+	blockChunkSize := uint64(100000)
+	blockChunkSizeStr := os.Getenv("BLOCK_CHUNK_SIZE")
+	if blockChunkSizeStr != "" {
+		// Try to parse the block chunk size as uint64
+		if size, err := strconv.ParseUint(blockChunkSizeStr, 10, 64); err == nil {
+			blockChunkSize = size
+		} else {
+			logger.Fatal("Invalid BLOCK_CHUNK_SIZE value: %s", blockChunkSizeStr)
+		}
+	}
 
 	corsEnv := os.Getenv("CORS")
 	var config Config
@@ -172,6 +183,7 @@ func LoadNetworkConfig() (Config, error) {
 			LidoKeysApiUrl:                  "https://keys-api-holesky.testnet.fi",
 			ProxyApiPort:                    proxyApiPort,
 			MinGenesisTime:                  uint64(1695902400),
+			BlockChunkSize:                  blockChunkSize,
 		}
 	case "mainnet":
 		// Configure default values for the mainnet
@@ -211,7 +223,7 @@ func LoadNetworkConfig() (Config, error) {
 			CSModuleTxReceipt:               common.HexToHash("0xf5330dbcf09885ed145c4435e356b5d8a10054751bb8009d3a2605d476ac173f"),
 			LidoKeysApiUrl:                  "https://keys-api.lido.fi",
 			ProxyApiPort:                    proxyApiPort,
-			MinGenesisTime:                  uint64(1606824023),
+			MinGenesisTime:                  blockChunkSize,
 		}
 	default:
 		logger.Fatal("Unknown network: %s", network)


### PR DESCRIPTION
Allow to scan by pre-defined block ranges in events scanners. This way the eth nodes can be queried by smaller block ranges avoiding timeout or limit errors