### PR TITLE
Relocate skip scanner to csmoduleEvents

### DIFF
--- a/internal/application/services/csModuleEventsScanner.go
+++ b/internal/application/services/csModuleEventsScanner.go
@@ -71,6 +71,12 @@ func (cs *CsModuleEventsScanner) ScanAddressEvents(ctx context.Context, address 
 		return nil
 	}
 
+	// return if distance is less than 10 epoch = 10 * 32 blocks
+	if end-start < 320 {
+		logger.InfoWithPrefix(cs.servicePrefix, "Block distance is less than 320 blocks (10 epochs), skipping scan")
+		return nil
+	}
+
 	if err := cs.csModulePort.ScanNodeOperatorEvents(
 		ctx,
 		address,

--- a/internal/application/services/distributionLogUpdatedEventScanner.go
+++ b/internal/application/services/distributionLogUpdatedEventScanner.go
@@ -103,12 +103,6 @@ func (ds *DistributionLogUpdatedEventScanner) runScan(ctx context.Context) {
 		return
 	}
 
-	// return if distance is less than 10 epoch = 10 * 32 blocks
-	if end-start < 320 {
-		logger.InfoWithPrefix(ds.servicePrefix, "Block distance is less than 320 blocks (10 epochs), skipping scan")
-		return
-	}
-
 	// Perform the scan
 	if err := ds.csFeeDistributorImplPort.ScanDistributionLogUpdatedEvents(ctx, start, &end, ds.HandleDistributionLogUpdatedEvent); err != nil {
 		logger.ErrorWithPrefix(ds.servicePrefix, "Error scanning DistributionLogUpdated events: %v", err)


### PR DESCRIPTION
Relocate skip scanner to csmoduleEvents instead of distributionlogUpdated