### PR TITLE
Allow to define BlockScannerMinDistance

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,23 +50,32 @@
     - `GET /api/v0/event_indexer/address_events`: Retrieves the eventes associated to an EA
       - query params:
         - `address`: Address to get events.
+    - `GET /api/v0/event_indexer/address_events`: Retrieves the eventes associated to an EA
+      - query params:
+        - `address`: Address to get events.
+    - `GET /api/v0/events_indexer/withdrawals_submitted`: Retrieves the withdrawals submitted by an operator
+      - query params:
+        - `operatorId`: Operator ID to get withdrawals submitted.
+    - `GET /api/v0/events_indexer/el_rewards_stealing_penalties_reported`: Retrieves the rewards stealing penalties reported by Lido
 - Proxy API: a proxy API that redirect requests to the [Lico API keys](https://github.com/lidofinance/lido-keys-api). Its main functionality is to avoid the cors issues when the Lido CSM UI tries to fetch the API.
 
 ## Environment Variables
 
 To configure the app, set the following environment variables:
 
-| Variable         | Description                                                                                          |
-|------------------|------------------------------------------------------------------------------------------------------|
-| `NETWORK`        | Ethereum network (e.g., `mainnet`, `holesky`). Default holesky                                       |
-| `API_PORT`       | Port on which the API will be exposed. Default 8080                                                  |
-| `PROXY_API_PORT` | Proxy port on which the Proxy API will be exposed. Default 8081                                                 |
-| `BEACONCHAIN_URL`| URL of the Ethereum beacon chain client. Default http://beacon-chain.<network>,dncore.dappnode:3500  |
-| `WS_URL`         | URL of the Ethereum WebSocket client. Default ws://execution.<network>.dncore.dappnode:8546          |
-| `RPC_URL`        | URL of the Ethereum RPC client. Default http://execution.<network>.dncore.dappnode:8545              |
-| `IPFS_URL`       | URL of the IPFS gateway used to fetch logs. Default http://ipfs.dappnode:5001                        |
-| `LOG_LEVEL`      | Logging level (e.g., `DEBUG`, `INFO`, `WARN`, `ERROR`). Default INFO                                 |
-| `CORS`           | CORS origins domains allowed to fetch the api. Default to Lido CSM ui                                |
+| Variable                     | Description                                                                                          |
+|------------------------------|------------------------------------------------------------------------------------------------------|
+| `NETWORK`                    | Ethereum network (e.g., `mainnet`, `holesky`). Default holesky                                       |
+| `API_PORT`                   | Port on which the API will be exposed. Default 8080                                                  |
+| `PROXY_API_PORT`             | Proxy port on which the Proxy API will be exposed. Default 8081                                      |
+| `BEACONCHAIN_URL`            | URL of the Ethereum beacon chain client. Default http://beacon-chain.<network>,dncore.dappnode:3500  |
+| `WS_URL`                     | URL of the Ethereum WebSocket client. Default ws://execution.<network>.dncore.dappnode:8546          |
+| `RPC_URL`                    | URL of the Ethereum RPC client. Default http://execution.<network>.dncore.dappnode:8545              |
+| `IPFS_URL`                   | URL of the IPFS gateway used to fetch logs. Default http://ipfs.dappnode:5001                        |
+| `LOG_LEVEL`                  | Logging level (e.g., `DEBUG`, `INFO`, `WARN`, `ERROR`). Default INFO                                 |
+| `CORS`                       | CORS origins domains allowed to fetch the api. Default to Lido CSM ui                                |
+| `BLOCK_CHUNK_SIZE`           | Defines the block chunk size to scan long block ranges                                               |
+| `BLOCK_SCANNER_MIN_DISTANCE` | Defines the minimum block distance required to trigger a scan. Used to avoid spamming nodes          |
 
 Example `.env` file:
 

--- a/internal/application/services/csModuleEventsScanner.go
+++ b/internal/application/services/csModuleEventsScanner.go
@@ -17,16 +17,18 @@ type CsModuleEventsScanner struct {
 	csModulePort                    ports.CsModulePort
 	csFeeDistributorBlockDeployment uint64
 	csModuleTxReceipt               common.Hash
+	BlockScannerMinDistance         uint64
 	servicePrefix                   string
 }
 
-func NewCsModuleEventsScanner(storagePort ports.StoragePort, executionPort ports.ExecutionPort, csModulePort ports.CsModulePort, csFeeDistributorBlockDeployment uint64, csModuleTxReceipt common.Hash) *CsModuleEventsScanner {
+func NewCsModuleEventsScanner(storagePort ports.StoragePort, executionPort ports.ExecutionPort, csModulePort ports.CsModulePort, csFeeDistributorBlockDeployment uint64, csModuleTxReceipt common.Hash, blockScannerMinDistance uint64) *CsModuleEventsScanner {
 	return &CsModuleEventsScanner{
 		storagePort:                     storagePort,
 		executionPort:                   executionPort,
 		csModulePort:                    csModulePort,
 		csFeeDistributorBlockDeployment: csFeeDistributorBlockDeployment,
 		csModuleTxReceipt:               csModuleTxReceipt,
+		BlockScannerMinDistance:         blockScannerMinDistance,
 		servicePrefix:                   "CsModuleEventsScanner",
 	}
 }
@@ -73,7 +75,7 @@ func (cs *CsModuleEventsScanner) ScanWithdrawalsSubmittedEvents(ctx context.Cont
 	}
 
 	// return if distance is less than 10 epoch = 10 * 32 blocks
-	if end-start < 320 {
+	if end-start < cs.BlockScannerMinDistance {
 		logger.InfoWithPrefix(cs.servicePrefix, "Block distance is less than 320 blocks (10 epochs), skipping scan")
 		return nil
 	}
@@ -141,7 +143,7 @@ func (cs *CsModuleEventsScanner) ScanElRewardsStealingPenaltyReported(ctx contex
 	}
 
 	// return if distance is less than 10 epoch = 10 * 32 blocks
-	if end-start < 320 {
+	if end-start < cs.BlockScannerMinDistance {
 		logger.InfoWithPrefix(cs.servicePrefix, "Block distance is less than 320 blocks (10 epochs), skipping scan")
 		return nil
 	}
@@ -206,7 +208,7 @@ func (cs *CsModuleEventsScanner) ScanAddressEvents(ctx context.Context, address 
 	}
 
 	// return if distance is less than 10 epoch = 10 * 32 blocks
-	if end-start < 320 {
+	if end-start < cs.BlockScannerMinDistance {
 		logger.InfoWithPrefix(cs.servicePrefix, "Block distance is less than 320 blocks (10 epochs), skipping scan")
 		return nil
 	}

--- a/internal/config/config_loader.go
+++ b/internal/config/config_loader.go
@@ -48,8 +48,9 @@ type Config struct {
 	ProxyApiPort   uint64
 
 	// Blockchain
-	MinGenesisTime uint64
-	BlockChunkSize uint64
+	MinGenesisTime          uint64
+	BlockChunkSize          uint64
+	BlockScannerMinDistance uint64
 }
 
 // Helper function to parse and validate CORS from environment variable
@@ -140,6 +141,17 @@ func LoadNetworkConfig() (Config, error) {
 		}
 	}
 
+	blockScannerMinDistance := uint64(320) // 320 blocks = 10 epochs
+	blockScannerMinDistanceStr := os.Getenv("BLOCK_SCANNER_MIN_DISTANCE")
+	if blockScannerMinDistanceStr != "" {
+		// Try to parse the block scanner min distance as uint64
+		if distance, err := strconv.ParseUint(blockScannerMinDistanceStr, 10, 64); err == nil {
+			blockScannerMinDistance = distance
+		} else {
+			logger.Fatal("Invalid BLOCK_SCANNER_MIN_DISTANCE value: %s", blockScannerMinDistanceStr)
+		}
+	}
+
 	corsEnv := os.Getenv("CORS")
 	var config Config
 
@@ -184,6 +196,7 @@ func LoadNetworkConfig() (Config, error) {
 			ProxyApiPort:                    proxyApiPort,
 			MinGenesisTime:                  uint64(1695902400),
 			BlockChunkSize:                  blockChunkSize,
+			BlockScannerMinDistance:         blockScannerMinDistance,
 		}
 	case "mainnet":
 		// Configure default values for the mainnet
@@ -225,6 +238,7 @@ func LoadNetworkConfig() (Config, error) {
 			ProxyApiPort:                    proxyApiPort,
 			MinGenesisTime:                  uint64(1606824023),
 			BlockChunkSize:                  blockChunkSize,
+			BlockScannerMinDistance:         blockScannerMinDistance,
 		}
 	default:
 		logger.Fatal("Unknown network: %s", network)


### PR DESCRIPTION
Allow to define BlockScannerMinDistance used to define the minimum block distance required to trigger a scan. This caching allows to avoid spamming local eth nodes. Defaults to 320 blocks = 10 epochs