### PR TITLE
Add "giveUp" flag on pending hashes loader

### DIFF
--- a/internal/application/services/api_server.go
+++ b/internal/application/services/api_server.go
@@ -564,7 +564,7 @@ func (h *APIServerService) getOperatorPerformance(w http.ResponseWriter, r *http
 	}
 
 	// Load the pending hashes
-	if err := h.pendingHashesLoader.LoadPendingHashes(); err != nil {
+	if err := h.pendingHashesLoader.LoadPendingHashes(true); err != nil {
 		logger.ErrorWithPrefix(h.servicePrefix, "Error loading pending hashes: %v", err)
 		writeErrorResponse(w, "Error loading pending hashes", http.StatusInternalServerError, err)
 		return

--- a/internal/application/services/loadPendingHashes.go
+++ b/internal/application/services/loadPendingHashes.go
@@ -104,7 +104,7 @@ func (phl *PendingHashesLoader) LoadPendingHashes(giveUp bool) error {
 				// giveUp flag is set to true when we dont want to retry fetching the data of all pending hashes.
 				// This is useful if we want this function to finish somewhat quickly and not wait for all pending hashes to be fetched.
 				if giveUp {
-					logger.DebugWithPrefix(phl.servicePrefix, "Skipping the rest of the pending hashes")
+					logger.DebugWithPrefix(phl.servicePrefix, "Called with 'giveUp' flag set to true, skipping the rest of the pending hashes")
 					return nil
 				}
 				continue


### PR DESCRIPTION
New flag "giveUp" makes pending hashes loader not try to fetch all pending hashes when called when one cant be fetched.

Useful for the `operator_performance` endpoint of the API, where we dont want to wait minutes for one request to end
