### PR TITLE
Check isTimeout in `FetchAndParseIpfs`

### DIFF
--- a/internal/adapters/ipfs/ipfs_adapter_integration_test.go
+++ b/internal/adapters/ipfs/ipfs_adapter_integration_test.go
@@ -23,7 +23,7 @@ func TestFetchAndParseIpfs(t *testing.T) {
 	cid := "QmTN9oYsjcJjGMpRrT2PZD4iY6aJpy5aCSBvGKU2a9EMQF"
 
 	// Fetch and parse the report from IPFS
-	report, err := adapter.FetchAndParseIpfs(cid)
+	report, _, err := adapter.FetchAndParseIpfs(cid)
 	if err != nil {
 		t.Fatalf("failed to fetch and parse IPFS data: %v", err)
 	}

--- a/internal/application/ports/ipfs_port.go
+++ b/internal/application/ports/ipfs_port.go
@@ -3,5 +3,5 @@ package ports
 import "lido-events/internal/application/domain"
 
 type IpfsPort interface {
-	FetchAndParseIpfs(cid string) (domain.OriginalReport, error)
+	FetchAndParseIpfs(cid string) (domain.OriginalReport, bool, error)
 }

--- a/internal/application/services/loadPendingHashes.go
+++ b/internal/application/services/loadPendingHashes.go
@@ -98,12 +98,12 @@ func (phl *PendingHashesLoader) LoadPendingHashes(giveUp bool) error {
 		for _, pendingHash := range pendingHashes {
 			logger.DebugWithPrefix(phl.servicePrefix, "Fetching and parsing IPFS data for pending hash %s", pendingHash)
 
-			originalReport, err := phl.ipfsPort.FetchAndParseIpfs(pendingHash)
+			originalReport, isTimeout, err := phl.ipfsPort.FetchAndParseIpfs(pendingHash)
 			if err != nil {
 				logger.ErrorWithPrefix(phl.servicePrefix, "Failed to fetch and parse IPFS data for pending hash %s, skipping hash: %v", pendingHash, err)
 				// giveUp flag is set to true when we dont want to retry fetching the data of all pending hashes.
 				// This is useful if we want this function to finish somewhat quickly and not wait for all pending hashes to be fetched.
-				if giveUp {
+				if giveUp && isTimeout {
 					logger.DebugWithPrefix(phl.servicePrefix, "Called with 'giveUp' flag set to true, skipping the rest of the pending hashes")
 					return nil
 				}

--- a/internal/mocks/ipfs_mock.go
+++ b/internal/mocks/ipfs_mock.go
@@ -12,7 +12,7 @@ type MockIpfsPort struct {
 }
 
 // FetchAndParseIpfs simulates fetching and parsing an IPFS content by CID
-func (m *MockIpfsPort) FetchAndParseIpfs(cid string) (domain.OriginalReport, error) {
+func (m *MockIpfsPort) FetchAndParseIpfs(cid string) (domain.OriginalReport, bool, error) {
 	args := m.Called(cid)
-	return args.Get(0).(domain.OriginalReport), args.Error(1)
+	return args.Get(0).(domain.OriginalReport), false, args.Error(1)
 }


### PR DESCRIPTION
`FetchAndParseIpfs` now returns a new argument, `isTimeout bool`. It is true only if response code of ipfs gateway is `StatusGatewayTimeout` or `StatusRequestTimeout`.

`LoadPendingHashes` will now skip if called with the `giveUp` boolean is set to `true` and `isTimeout` is also `true`